### PR TITLE
Add TimeRateLimit connection in AI configuration

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/io/AI/logiBUS_AI_IDA.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/io/AI/logiBUS_AI_IDA.fbt
@@ -72,6 +72,7 @@
 			<Connection Source="AnalogInput_hysteresis" Destination="AI.AnalogInput_hysteresis" dx1="1320"/>
 			<Connection Source="SREQ.D1" Destination="E_R_TRIG.QI"/>
 			<Connection Source="TimeDelta" Destination="AI.TimeDelta" dx1="1180"/>
+			<Connection Source="TimeRateLimit" Destination="AI.TimeRateLimit" dx1="1060"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Introduce a new connection for TimeRateLimit to the AI instance for enhanced rate control. Ensures the AI component can manage input changes more effectively by limiting rate fluctuations.

## Summary by Sourcery

No effective code or configuration changes are visible in the provided diff; the file appears unchanged in this pull request.