### PR TITLE
Add unidirectional multiplexor and demultiplexor function block types

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BOOL/AX_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BOOL/AX_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AX_MUX_4" Comment="AX multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AX" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AX" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AX" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AX" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AX_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BOOL/AX_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BOOL/AX_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AX_MUX_5" Comment="AX multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AX" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AX" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AX" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AX" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AX" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AX_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_DEMUX_2" Comment="AB demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AB"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AB" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_DEMUX_3" Comment="AB demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AB"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AB" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_DEMUX_4" Comment="AB demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AB"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AB" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_DEMUX_5" Comment="AB demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AB"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AB"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AB" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_MUX_2" Comment="AB multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_MUX_3" Comment="AB multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_MUX_4" Comment="AB multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/BYTE/AB_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_MUX_5" Comment="AB multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_DEMUX_2" Comment="ADI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ADI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ADI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_DEMUX_3" Comment="ADI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ADI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ADI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_DEMUX_4" Comment="ADI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ADI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ADI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_DEMUX_5" Comment="ADI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ADI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::ADI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ADI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_MUX_2" Comment="ADI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ADI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ADI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_MUX_3" Comment="ADI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ADI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ADI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ADI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_MUX_4" Comment="ADI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ADI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ADI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ADI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ADI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DINT/ADI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ADI_MUX_5" Comment="ADI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ADI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ADI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ADI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ADI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::ADI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ADI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_DEMUX_2" Comment="AD demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AD"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AD" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_DEMUX_3" Comment="AD demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AD"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AD" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_DEMUX_4" Comment="AD demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AD"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AD" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_DEMUX_5" Comment="AD demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AD"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AD"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AD" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_MUX_2" Comment="AD multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_MUX_3" Comment="AD multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_MUX_4" Comment="AD multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/DWORD/AD_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_MUX_5" Comment="AD multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_DEMUX_2" Comment="AE demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AE"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AE" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_DEMUX_3" Comment="AE demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AE"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AE" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_DEMUX_4" Comment="AE demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AE"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AE" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_DEMUX_5" Comment="AE demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AE"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AE"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AE" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_MUX_2" Comment="AE multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AE" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AE" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AE" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_MUX_3" Comment="AE multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AE" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AE" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AE" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AE" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_MUX_4" Comment="AE multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AE" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AE" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AE" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AE" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AE" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/EVENT/AE_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_MUX_5" Comment="AE multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AE" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AE" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AE" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AE" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AE" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AE" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AE_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_DEMUX_2" Comment="AI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_DEMUX_3" Comment="AI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_DEMUX_4" Comment="AI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_DEMUX_5" Comment="AI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_MUX_2" Comment="AI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_MUX_3" Comment="AI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_MUX_4" Comment="AI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/INT/AI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AI_MUX_5" Comment="AI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_DEMUX_2" Comment="ALI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_DEMUX_3" Comment="ALI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_DEMUX_4" Comment="ALI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ALI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_DEMUX_5" Comment="ALI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ALI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::ALI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_MUX_2" Comment="ALI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_MUX_3" Comment="ALI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_MUX_4" Comment="ALI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ALI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LINT/ALI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALI_MUX_5" Comment="ALI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ALI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::ALI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_DEMUX_2" Comment="ALR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_DEMUX_3" Comment="ALR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_DEMUX_4" Comment="ALR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ALR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_DEMUX_5" Comment="ALR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ALR"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::ALR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ALR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_MUX_2" Comment="ALR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALR" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_MUX_3" Comment="ALR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALR" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_MUX_4" Comment="ALR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALR" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ALR" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LREAL/ALR_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ALR_MUX_5" Comment="ALR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ALR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ALR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ALR" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ALR" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::ALR" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ALR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_DEMUX_2" Comment="AL demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AL"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AL" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_DEMUX_3" Comment="AL demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AL"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AL" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_DEMUX_4" Comment="AL demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AL"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AL" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_DEMUX_5" Comment="AL demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AL"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AL"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AL" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_MUX_2" Comment="AL multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_MUX_3" Comment="AL multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_MUX_4" Comment="AL multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/LWORD/AL_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_MUX_5" Comment="AL multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_DEMUX_2" Comment="AQ demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AQ"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AQ" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_DEMUX_3" Comment="AQ demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AQ"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AQ" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_DEMUX_4" Comment="AQ demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AQ"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AQ" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_DEMUX_5" Comment="AQ demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AQ"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AQ"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AQ" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_MUX_2" Comment="AQ multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_MUX_3" Comment="AQ multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_MUX_4" Comment="AQ multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/QUARTER/AQ_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_MUX_5" Comment="AQ multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_DEMUX_2" Comment="AR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_DEMUX_3" Comment="AR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_DEMUX_4" Comment="AR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_DEMUX_5" Comment="AR demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AR"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AR"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AR" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_MUX_2" Comment="AR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AR" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_MUX_3" Comment="AR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AR" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_MUX_4" Comment="AR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AR" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AR" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/REAL/AR_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_MUX_5" Comment="AR multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AR" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AR" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AR" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AR" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AR_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_DEMUX_2" Comment="AS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_DEMUX_3" Comment="AS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_DEMUX_4" Comment="AS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_DEMUX_5" Comment="AS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AS"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_MUX_2" Comment="AS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AS" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AS" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_MUX_3" Comment="AS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AS" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_MUX_4" Comment="AS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AS" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/SINT/AS_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AS_MUX_5" Comment="AS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AS" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AS" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_DEMUX_2" Comment="AIS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_DEMUX_3" Comment="AIS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_DEMUX_4" Comment="AIS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AIS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_DEMUX_5" Comment="AIS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AIS"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AIS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_MUX_2" Comment="AIS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIS" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIS" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_MUX_3" Comment="AIS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIS" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_MUX_4" Comment="AIS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AIS" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/STRING/AIS_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIS_MUX_5" Comment="AIS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AIS" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AIS" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_DEMUX_2" Comment="ATM demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_DEMUX_3" Comment="ATM demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_DEMUX_4" Comment="ATM demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_DEMUX_5" Comment="ATM demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ATM"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_MUX_2" Comment="ATM multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_MUX_3" Comment="ATM multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ATM" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_MUX_4" Comment="ATM multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ATM" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ATM" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/TIME/ATM_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_MUX_5" Comment="ATM multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ATM" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ATM" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::ATM" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_DEMUX_2" Comment="AUDI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUDI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUDI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_DEMUX_3" Comment="AUDI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUDI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUDI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_DEMUX_4" Comment="AUDI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUDI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUDI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_DEMUX_5" Comment="AUDI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUDI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AUDI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUDI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_MUX_2" Comment="AUDI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_MUX_3" Comment="AUDI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUDI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_MUX_4" Comment="AUDI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUDI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUDI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UDINT/AUDI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUDI_MUX_5" Comment="AUDI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUDI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUDI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AUDI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUDI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_DEMUX_2" Comment="AUI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_DEMUX_3" Comment="AUI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_DEMUX_4" Comment="AUI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_DEMUX_5" Comment="AUI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AUI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_MUX_2" Comment="AUI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_MUX_3" Comment="AUI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_MUX_4" Comment="AUI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/UINT/AUI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUI_MUX_5" Comment="AUI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AUI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_DEMUX_2" Comment="AULI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AULI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AULI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_DEMUX_3" Comment="AULI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AULI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AULI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_DEMUX_4" Comment="AULI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AULI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AULI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_DEMUX_5" Comment="AULI demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AULI"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AULI"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AULI" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_MUX_2" Comment="AULI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AULI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AULI" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_MUX_3" Comment="AULI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AULI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AULI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AULI" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_MUX_4" Comment="AULI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AULI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AULI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AULI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AULI" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/ULINT/AULI_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AULI_MUX_5" Comment="AULI multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AULI" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AULI" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AULI" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AULI" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AULI" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AULI_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_DEMUX_2" Comment="AUS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_DEMUX_3" Comment="AUS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_DEMUX_4" Comment="AUS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_DEMUX_5" Comment="AUS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AUS"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AUS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AUS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_MUX_2" Comment="AUS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUS" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUS" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_MUX_3" Comment="AUS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUS" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_MUX_4" Comment="AUS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUS" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/USINT/AUS_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AUS_MUX_5" Comment="AUS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AUS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AUS" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AUS" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AUS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_DEMUX_2" Comment="AW demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AW"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AW" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_DEMUX_3" Comment="AW demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AW"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AW" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_DEMUX_4" Comment="AW demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AW"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AW" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_DEMUX_5" Comment="AW demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AW"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AW"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AW" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_MUX_2" Comment="AW multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_MUX_3" Comment="AW multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_MUX_4" Comment="AW multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WORD/AW_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_MUX_5" Comment="AW multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_DEMUX_2" Comment="AIWS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIWS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIWS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_DEMUX_3" Comment="AIWS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIWS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIWS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_DEMUX_4" Comment="AIWS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AIWS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIWS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_DEMUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_DEMUX_5" Comment="AIWS demultiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+            <AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::AIWS"/>
+            <AdapterDeclaration Name="OUT5" Type="adapter::types::unidirectional::AIWS"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AIWS" Comment="Input Value to demultiplex"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_DEMUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_2.fbt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_MUX_2" Comment="AIWS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIWS" Comment="IN1 for K = 0, IN2 for K = 1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIWS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIWS" Comment="Input value 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_3.fbt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_MUX_3" Comment="AIWS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIWS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIWS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIWS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIWS" Comment="Input value 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_4.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_MUX_4" Comment="AIWS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIWS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIWS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIWS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIWS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AIWS" Comment="Input value 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/selection/unidirectional/WSTRING/AIWS_MUX_5.fbt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AIWS_MUX_5" Comment="AIWS multiplexor (generic FB)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::selection::unidirectional">
+		<Import declaration="eclipse4diac::core::TypeHash"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Set Index K">
+				<With Var="K"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Set Index K">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="K" Type="UINT" Comment="index"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIWS" Comment="IN1 for K = 0, IN2 for K = 1, IN3 for K = 2, IN4 for K = 3, IN5 for K = 4"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AIWS" Comment="Input value 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AIWS" Comment="Input value 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AIWS" Comment="Input value 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AIWS" Comment="Input value 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AIWS" Comment="Input value 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AIWS_MUX'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Introduce several new function block types for unidirectional multiplexor and demultiplexor operations across different data types (e.g., BOOL, BYTE, DINT). These additions support enhanced data routing and management within applications, adhering to the IEC 61499 standard.

## Summary by Sourcery

Add a comprehensive set of unidirectional multiplexor and demultiplexor function block types for IEC 61499 applications.

New Features:
- Introduce unidirectional MUX and DEMUX function blocks for a wide range of IEC 61499 data types (e.g., BOOL, integer types, real types, strings, time, and events).
- Provide standardized 2-to-5 channel variants of these MUX/DEMUX blocks to support flexible signal routing in the adapter library.