### PR TITLE
Add ASR adapter connections for edge detection enhancements

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_ASR_RF_TRIG.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_ASR_RF_TRIG.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AX_RF_TRIG" Comment="Boolean falling and rising edge detection">
+<FBType Name="AX_ASR_RF_TRIG" Comment="Boolean falling and rising edge detection">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-08" Remarks="initial API and implementation and/or initial documentation">
@@ -7,26 +7,23 @@
 	<CompilerInfo packageName="adapter::events::unidirectional">
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="ER" Type="Event" Comment="confirmation that a rising edge was detected">
-			</Event>
-			<Event Name="EF" Type="Event" Comment="confirmation that a falling edge was detected">
-			</Event>
-		</EventOutputs>
+		<Plugs>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::ASR" Comment="Set/Reset Output" x="1400" y="-700"/>
+		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="QI" Type="adapter::types::unidirectional::AX" Comment="value to check for a rising or falling edge" x="-900" y="-600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_RF_TRIG" Type="iec61499::events::E_RF_TRIG" x="500" y="-600">
+		<FB Name="E_RF_TRIG" Type="iec61499::events::E_RF_TRIG" x="0" y="-700">
 		</FB>
 		<EventConnections>
-			<Connection Source="QI.E1" Destination="E_RF_TRIG.EI"/>
-			<Connection Source="E_RF_TRIG.ER" Destination="ER" dx1="1966.67"/>
-			<Connection Source="E_RF_TRIG.EF" Destination="EF" dx1="2173.33"/>
+			<Connection Source="QI.E1" Destination="E_RF_TRIG.EI" dx1="260"/>
+			<Connection Source="E_RF_TRIG.ER" Destination="Q.SET"/>
+			<Connection Source="E_RF_TRIG.EF" Destination="Q.RESET"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="QI.D1" Destination="E_RF_TRIG.QI" dx1="506.67"/>
+			<Connection Source="QI.D1" Destination="E_RF_TRIG.QI" dx1="260"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_ASR_RF_TRIG_X.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_ASR_RF_TRIG_X.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AX_RF_TRIG" Comment="Boolean falling and rising edge detection">
+<FBType Name="AX_ASR_RF_TRIG_X" Comment="Boolean falling and rising edge detection (Crossed mapping: raising=RESET, falling=SET)">
 	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH, HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-08" Remarks="initial API and implementation and/or initial documentation">
@@ -7,26 +7,23 @@
 	<CompilerInfo packageName="adapter::events::unidirectional">
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="ER" Type="Event" Comment="confirmation that a rising edge was detected">
-			</Event>
-			<Event Name="EF" Type="Event" Comment="confirmation that a falling edge was detected">
-			</Event>
-		</EventOutputs>
+		<Plugs>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::ASR" Comment="Set/Reset Output" x="1500" y="-700"/>
+		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="QI" Type="adapter::types::unidirectional::AX" Comment="value to check for a rising or falling edge" x="-900" y="-600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_RF_TRIG" Type="iec61499::events::E_RF_TRIG" x="500" y="-600">
+		<FB Name="E_RF_TRIG" Type="iec61499::events::E_RF_TRIG" x="200" y="-700">
 		</FB>
 		<EventConnections>
-			<Connection Source="QI.E1" Destination="E_RF_TRIG.EI"/>
-			<Connection Source="E_RF_TRIG.ER" Destination="ER" dx1="1966.67"/>
-			<Connection Source="E_RF_TRIG.EF" Destination="EF" dx1="2173.33"/>
+			<Connection Source="QI.E1" Destination="E_RF_TRIG.EI" dx1="360"/>
+			<Connection Source="E_RF_TRIG.EF" Destination="Q.SET" dx1="293.33"/>
+			<Connection Source="E_RF_TRIG.ER" Destination="Q.RESET" dx1="293.33"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="QI.D1" Destination="E_RF_TRIG.QI" dx1="506.67"/>
+			<Connection Source="QI.D1" Destination="E_RF_TRIG.QI" dx1="360"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_E_SWITCH.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_E_SWITCH.fbt
@@ -19,7 +19,7 @@
 			</Event>
 		</EventOutputs>
 		<Sockets>
-			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EI0 when G=0, to EI1 when G=1" x="-100" y="300"/>
+			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EO0 when G=0, to EO1 when G=1" x="-100" y="300"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_F_TRIG.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_F_TRIG.fbt
@@ -18,18 +18,14 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="0" y="200">
-		</FB>
-		<FB Name="E_SWITCH" Type="iec61499::events::E_SWITCH" x="1000" y="100">
+		<FB Name="E_F_TRIG" Type="iec61499::events::E_F_TRIG" x="0" y="100">
 		</FB>
 		<EventConnections>
-			<Connection Source="E_D_FF.EO" Destination="E_SWITCH.EI" dx1="353.33"/>
-			<Connection Source="E_SWITCH.EO0" Destination="EO" dx1="2373.33"/>
-			<Connection Source="QI.E1" Destination="E_D_FF.CLK" dx1="406.67"/>
+			<Connection Source="QI.E1" Destination="E_F_TRIG.EI"/>
+			<Connection Source="E_F_TRIG.EO" Destination="EO" dx1="2240"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="E_D_FF.Q" Destination="E_SWITCH.G" dx1="353.33"/>
-			<Connection Source="QI.D1" Destination="E_D_FF.D" dx1="406.67"/>
+			<Connection Source="QI.D1" Destination="E_F_TRIG.QI"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_R_TRIG.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_R_TRIG.fbt
@@ -18,18 +18,14 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="300" y="100">
-		</FB>
-		<FB Name="E_SWITCH" Type="iec61499::events::E_SWITCH" x="1400" y="100">
+		<FB Name="E_R_TRIG" Type="iec61499::events::E_R_TRIG" x="600" y="100">
 		</FB>
 		<EventConnections>
-			<Connection Source="E_D_FF.EO" Destination="E_SWITCH.EI"/>
-			<Connection Source="E_SWITCH.EO1" Destination="EO" dx1="1266.67"/>
-			<Connection Source="QI.E1" Destination="E_D_FF.CLK"/>
+			<Connection Source="QI.E1" Destination="E_R_TRIG.EI"/>
+			<Connection Source="E_R_TRIG.EO" Destination="EO" dx1="1940"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="E_D_FF.Q" Destination="E_SWITCH.G" dx1="266.67"/>
-			<Connection Source="QI.D1" Destination="E_D_FF.D"/>
+			<Connection Source="QI.D1" Destination="E_R_TRIG.QI"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_SWITCH.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/BOOL/AX_SWITCH.fbt
@@ -15,7 +15,7 @@
 			</Event>
 		</EventOutputs>
 		<Sockets>
-			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EI0 when G=0, to EI1 when G=1" x="133.33" y="80"/>
+			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EO0 when G=0, to EO1 when G=1" x="133.33" y="80"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/EVENT/AE_AX_SWITCH.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/EVENT/AE_AX_SWITCH.fbt
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AE_AX_SWITCH" Comment="Switching (demultiplexing) an event based on boolean input G">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-21" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::unidirectional">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="EO0" Type="adapter::types::unidirectional::AE" Comment="Output, switched from EI when G=0"/>
+			<AdapterDeclaration Name="EO1" Type="adapter::types::unidirectional::AE" Comment="Output, switched from EI when G=1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="EI" Type="adapter::types::unidirectional::AE" Comment="Event Input"/>
+			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EO0 when G=0, to EO1 when G=1"/>
+		</Sockets>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="START" Comment="Initial State" x="550" y="425">
+			</ECState>
+			<ECState Name="G0" Comment="Issue EO0 when EI arrives with G=0" x="1700" y="730">
+				<ECAction Output="EO0.E1"/>
+			</ECState>
+			<ECState Name="G1" Comment="Issue EO1 when EI arrives with G=1" x="320" y="1020">
+				<ECAction Output="EO1.E1"/>
+			</ECState>
+			<ECTransition Source="G0" Destination="START" Condition="1" Comment="" x="1255" y="660"/>
+			<ECTransition Source="G1" Destination="START" Condition="1" Comment="" x="535" y="795"/>
+			<ECTransition Source="START" Destination="G0" Condition="EI.E1[NOT G.D1]" Comment="" x="1435" y="440"/>
+			<ECTransition Source="START" Destination="G1" Condition="EI.E1[G.D1]" Comment="" x="350" y="550"/>
+			<ECTransition Source="START" Destination="START" Condition="G.E1" Comment="" x="680" y="180"/>
+		</ECC>
+	</BasicFB>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/EVENT/ASR_AX_SWITCH.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/EVENT/ASR_AX_SWITCH.fbt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ASR_AX_SWITCH" Comment="Switching (demultiplexing) ASR events (SET/RESET) based on boolean input G">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-21" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::unidirectional">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="EO0" Type="adapter::types::unidirectional::ASR" Comment="Output, switched from EI when G=0"/>
+			<AdapterDeclaration Name="EO1" Type="adapter::types::unidirectional::ASR" Comment="Output, switched from EI when G=1"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="EI" Type="adapter::types::unidirectional::ASR" Comment="Event Input"/>
+			<AdapterDeclaration Name="G" Type="adapter::types::unidirectional::AX" Comment="Switch EI to EO0 when G=0, to EO1 when G=1"/>
+		</Sockets>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="START" Comment="Initial State" x="560" y="400">
+			</ECState>
+			<ECState Name="G0_SET" Comment="Issue EO0.SET when EI.SET arrives with G=0" x="1680" y="720">
+				<ECAction Output="EO0.SET"/>
+			</ECState>
+			<ECState Name="G1_SET" Comment="Issue EO1.SET when EI.SET arrives with G=1" x="1680" y="1200">
+				<ECAction Output="EO1.SET"/>
+			</ECState>
+			<ECState Name="G0_RESET" Comment="Issue EO0.RESET when EI.RESET arrives with G=0" x="1680" y="960">
+				<ECAction Output="EO0.RESET"/>
+			</ECState>
+			<ECState Name="G1_RESET" Comment="Issue EO1.RESET when EI.RESET arrives with G=1" x="1680" y="1360">
+				<ECAction Output="EO1.RESET"/>
+			</ECState>
+			<ECTransition Source="G0_SET" Destination="START" Condition="1" Comment="" x="1255" y="660"/>
+			<ECTransition Source="START" Destination="G0_SET" Condition="EI.SET[NOT G.D1]" Comment="" x="1435" y="440"/>
+			<ECTransition Source="START" Destination="G1_SET" Condition="EI.SET[G.D1]" Comment="" x="1006.67" y="1000"/>
+			<ECTransition Source="START" Destination="START" Condition="G.E1" Comment="" x="680" y="180"/>
+			<ECTransition Source="START" Destination="G0_RESET" Condition="EI.RESET[NOT G.D1]" Comment="" x="1213.33" y="766.67"/>
+			<ECTransition Source="G0_RESET" Destination="START" Condition="1" Comment="" x="1006.67" y="786.67"/>
+			<ECTransition Source="START" Destination="G1_RESET" Condition="EI.RESET[G.D1]" Comment="" x="653.33" y="1180"/>
+			<ECTransition Source="G1_SET" Destination="START" Condition="1" Comment="" x="840" y="1113.33"/>
+			<ECTransition Source="G1_RESET" Destination="START" Condition="1" Comment="" x="280" y="1266.67"/>
+		</ECC>
+	</BasicFB>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
This update refactors function blocks to use E_RF_TRIG, E_F_TRIG, and E_R_TRIG types for more efficient edge detection with adapters. It introduces new ASR adapter connections, replacing previous event outputs to streamline operations within edge-triggered events.

## Summary by Sourcery

Introduce ASR-based adapter function blocks for edge detection and update existing BOOL trigger adapters to integrate with the new approach.

New Features:
- Add AX_ASR_RF_TRIG and AX_ASR_RF_TRIG_X BOOL adapter function blocks for ASR-based rising/falling edge handling.

Enhancements:
- Refine existing AX_F_TRIG, AX_RF_TRIG, and AX_R_TRIG BOOL adapter function blocks to align with the new ASR adapter edge-detection scheme.