### PR TITLE
Add new IO data type definitions for DataPanel modules

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Dual_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Dual_SA.dtp
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_LO_DO_S_Dual_SA" Comment="DataPanel Modules with low IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::LO::DQ">
+		<Import declaration="DataPanel::io::LO::const::LO::LO_00"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO_S"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO::InvalidL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 217..224" InitialValue="LO_00"/>
+		<VarDeclaration Name="Up" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B forward, up, right, clockwise" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Down" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B backward, down, left, counter-clockwise" InitialValue="InvalidL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Octal_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Octal_SA.dtp
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_LO_DO_S_Octal_SA" Comment="DataPanel Modules with low IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.1" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::LO::DQ">
+		<Import declaration="DataPanel::io::LO::const::LO::LO_00"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO_S"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO::InvalidL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 217..224" InitialValue="LO_00"/>
+		<VarDeclaration Name="Port1" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port2" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port3" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port4" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port5" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port6" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port7" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+		<VarDeclaration Name="Port8" Type="DataPanel::io::LO::DQ::DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Single_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with low IO density/DQ/DataPanel_LO_DO_S_Single_SA.dtp
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_LO_DO_S_Single_SA" Comment="DataPanel Modules with low IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::LO::DQ">
+		<Import declaration="DataPanel::io::LO::const::LO::LO_00"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO_S"/>
+		<Import declaration="DataPanel::io::LO::DQ::DataPanel_LO_DO::InvalidL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 217..224" InitialValue="LO_00"/>
+		<VarDeclaration Name="Port" Type="DataPanel_LO_DO_S" Comment="Identify the Port 1A..4B" InitialValue="InvalidL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Dual_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Dual_SA.dtp
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_AI_S_Dual_SA" Comment="DataPanel Modules with medium IO density AI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::AI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI_S"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Up" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B forward, up, right, clockwise" InitialValue="Invalid"/>
+		<VarDeclaration Name="Down" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B backward, down, left, counter-clockwise" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Octal_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Octal_SA.dtp
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_AI_S_Octal_SA" Comment="DataPanel Modules with medium IO density AI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::AI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI_S"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port1" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port2" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port3" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port4" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port5" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port6" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port7" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port8" Type="DataPanel::io::MI::AI::DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Single_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/AI/DataPanel_MI_AI_S_Single_SA.dtp
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_AI_S_Single_SA" Comment="DataPanel Modules with medium IO density AI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::AI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI_S"/>
+		<Import declaration="DataPanel::io::MI::AI::DataPanel_MI_AI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port" Type="DataPanel_MI_AI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Dual_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Dual_SA.dtp
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DI_S_Dual_SA" Comment="DataPanel Modules with medium IO density DI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI_S"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Up" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B forward, up, right, clockwise" InitialValue="Invalid"/>
+		<VarDeclaration Name="Down" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B backward, down, left, counter-clockwise" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Octal_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Octal_SA.dtp
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DI_S_Octal_SA" Comment="DataPanel Modules with medium IO density DI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI_S"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port1" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port2" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port3" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port4" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port5" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port6" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port7" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port8" Type="DataPanel::io::MI::DI::DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Single_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DI/DataPanel_MI_DI_S_Single_SA.dtp
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DI_S_Single_SA" Comment="DataPanel Modules with medium IO density DI Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DI">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI_S"/>
+		<Import declaration="DataPanel::io::MI::DI::DataPanel_MI_DI::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port" Type="DataPanel_MI_DI_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Dual_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Dual_SA.dtp
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DO_S_Dual_SA" Comment="DataPanel Modules with medium IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DQ">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Up" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B forward, up, right, clockwise" InitialValue="Invalid"/>
+		<VarDeclaration Name="Down" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B backward, down, left, counter-clockwise" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Octal_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Octal_SA.dtp
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DO_S_Octal_SA" Comment="DataPanel Modules with medium IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DQ">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port1" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port2" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port3" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port4" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port5" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port6" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port7" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+		<VarDeclaration Name="Port8" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Single_SA.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/DataPanel_MI_DO_S_Single_SA.dtp
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="DataPanel_MI_DO_S_Single_SA" Comment="DataPanel Modules with medium IO density DO Struct + Source Address">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DQ">
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO::Invalid"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u8SAMember" Type="USINT" Comment="Node SA 224..239" InitialValue="MI_00"/>
+		<VarDeclaration Name="Port" Type="DataPanel_MI_DO_S" Comment="Identify the Port 1A..8B" InitialValue="Invalid"/>
+	</StructuredType>
+</DataType>


### PR DESCRIPTION
Introduce new XML-based data type definitions for various low and medium IO density DataPanel modules. These files define structured types with source addresses and port information, designed to accommodate diverse module configurations.

## Summary by Sourcery

Add IO data type definitions for low and medium density DataPanel I/O modules.

New Features:
- Introduce XML-based data type definition files for low-density digital output DataPanel modules with single, dual, and octal channel configurations.
- Add XML-based data type definition files for medium-density analog input, digital input, and digital output DataPanel modules with single, dual, and octal channel configurations.