### PR TITLE
Add structured data types for handling multiple Object IDs

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s1ObjectID.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s1ObjectID.dtp
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="s1ObjectID" Comment="a Struct holding 1 Object ID">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="isobus::UT::Q::types">
+		<Import declaration="isobus::UT::Q::const::IDs::ID_NULL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u16ObjId" Type="UINT" Comment="Object ID Softkey" InitialValue="ID_NULL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s2ObjectIDs.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s2ObjectIDs.dtp
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="s2ObjectIDs" Comment="a Struct holding 2 Object IDs">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="isobus::UT::Q::types">
+		<Import declaration="isobus::UT::Q::const::IDs::ID_NULL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u16ObjId" Type="UINT" Comment="Object ID Softkey" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjIdA" Type="UINT" Comment="Object ID AUX" InitialValue="ID_NULL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s3ObjectIDs.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s3ObjectIDs.dtp
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="s3ObjectIDs" Comment="a Struct holding 3 Object IDs">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="isobus::UT::Q::types">
+		<Import declaration="isobus::UT::Q::const::IDs::ID_NULL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u16ObjId" Type="UINT" Comment="Object ID Softkey" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjIdA" Type="UINT" Comment="Object ID AUX" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjIdB" Type="UINT" Comment="Object ID Button" InitialValue="ID_NULL"/>
+	</StructuredType>
+</DataType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s8ObjectIDs.dtp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/types/s8ObjectIDs.dtp
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DataType Name="s8ObjectIDs" Comment="a Struct holding 8 Object IDs">
+	<Identification>
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="isobus::UT::Q::types">
+		<Import declaration="isobus::UT::Q::const::IDs::ID_NULL"/>
+	</CompilerInfo>
+	<StructuredType>
+		<VarDeclaration Name="u16ObjId01" Type="UINT" Comment="Object ID 1" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId02" Type="UINT" Comment="Object ID 2" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId03" Type="UINT" Comment="Object ID 3" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId04" Type="UINT" Comment="Object ID 4" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId05" Type="UINT" Comment="Object ID 5" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId06" Type="UINT" Comment="Object ID 6" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId07" Type="UINT" Comment="Object ID 7" InitialValue="ID_NULL"/>
+		<VarDeclaration Name="u16ObjId08" Type="UINT" Comment="Object ID 8" InitialValue="ID_NULL"/>
+	</StructuredType>
+</DataType>


### PR DESCRIPTION
Introduce new XML DataType definitions for 1, 2, 3, and 8 Object IDs to support structured handling in isobus systems, enhancing modularity and consistency.

## Summary by Sourcery

Introduce new structured data type definitions for handling different counts of Object IDs in the isobus type library.

New Features:
- Add XML datatype definition for a single Object ID.
- Add XML datatype definition for two Object IDs.
- Add XML datatype definition for three Object IDs.
- Add XML datatype definition for eight Object IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new data type definitions to the ISOBUS type library, expanding the available types for object identification across single, dual, triple, and multi-instance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Meisterschulen-am-Ostbahnhof-Munchen/4diac_training1/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->