### PR TITLE
Rename START state to STOP in interlock function blocks for consistent state management

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/SPLIT_MI_DO_S_Dual_SA.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/SPLIT_MI_DO_S_Dual_SA.fbt
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SPLIT_MI_DO_S_Dual_SA" Comment="Splits a DataPanel_MI_DO_S_Dual_SA into 2 DataPanel_MI_DO_S_Single_SA">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DQ">
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Dual_SA"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Single_SA"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation of Requested Service">
+				<With Var="UP"/>
+				<With Var="DOWN"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Dual_SA" Comment="Dual Input"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="UP" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Single_SA" Comment=" forward, up, right, clockwise"/>
+			<VarDeclaration Name="DOWN" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Single_SA" Comment="backward, down, left, counter-clockwise"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ" Comment="Normally executed algorithm">
+			<ST><![CDATA[
+UP.u8SAMember := IN.u8SAMember;
+UP.Port := IN.Up;
+DOWN.u8SAMember := IN.u8SAMember;
+DOWN.Port := IN.Down;
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/SPLIT_MI_DO_S_Octal_SA.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules with medium IO density/DQ/SPLIT_MI_DO_S_Octal_SA.fbt
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="SPLIT_MI_DO_S_Octal_SA" Comment="Splits a DataPanel_MI_DO_S_Octal_SA into 8 DataPanel_MI_DO_S_Single_SA">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-05-28">
+	</VersionInfo>
+	<CompilerInfo packageName="DataPanel::io::MI::DQ">
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Octal_SA"/>
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO_S_Single_SA"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Comment="Service Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Comment="Confirmation of Requested Service">
+				<With Var="OUT1"/>
+				<With Var="OUT2"/>
+				<With Var="OUT3"/>
+				<With Var="OUT4"/>
+				<With Var="OUT5"/>
+				<With Var="OUT6"/>
+				<With Var="OUT7"/>
+				<With Var="OUT8"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="DataPanel_MI_DO_S_Octal_SA" Comment="Octal Input"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT1" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 1"/>
+			<VarDeclaration Name="OUT2" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 2"/>
+			<VarDeclaration Name="OUT3" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 3"/>
+			<VarDeclaration Name="OUT4" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 4"/>
+			<VarDeclaration Name="OUT5" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 5"/>
+			<VarDeclaration Name="OUT6" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 6"/>
+			<VarDeclaration Name="OUT7" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 7"/>
+			<VarDeclaration Name="OUT8" Type="DataPanel_MI_DO_S_Single_SA" Comment="Single Output 8"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+
+			<ECState Name="REQ" x="900" y="900">
+				<ECAction Algorithm="REQ" Output="CNF"/>
+			</ECState>
+
+		<Algorithm Name="REQ" Comment="Normally executed algorithm">
+			<ST><![CDATA[OUT1.u8SAMember := IN.u8SAMember;
+OUT1.Port := IN.Port1;
+OUT2.u8SAMember := IN.u8SAMember;
+OUT2.Port := IN.Port2;
+OUT3.u8SAMember := IN.u8SAMember;
+OUT3.Port := IN.Port3;
+OUT4.u8SAMember := IN.u8SAMember;
+OUT4.Port := IN.Port4;
+OUT5.u8SAMember := IN.u8SAMember;
+OUT5.Port := IN.Port5;
+OUT6.u8SAMember := IN.u8SAMember;
+OUT6.Port := IN.Port6;
+OUT7.u8SAMember := IN.u8SAMember;
+OUT7.Port := IN.Port7;
+OUT8.u8SAMember := IN.u8SAMember;
+OUT8.Port := IN.Port8;]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/const/all_colours.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/isobus-3.0.0/typelib/UT/Q/const/all_colours.gcf
@@ -500,6 +500,7 @@ GLOBALCONSTANTS all_colours
 		COLOR_229 : USINT := USINT#229; // #FFFF99, rgb(255, 255, 153), pale canary
 		COLOR_230 : USINT := USINT#230; // #FFFFCC, rgb(255, 255, 204), cream
 		COLOR_231 : USINT := USINT#231; // #FFFFFF, rgb(255, 255, 255), white, Weiß
+		(* Colors 232-255 reserved for manufacturer proprietary use per ISOBUS standard *)
 		COLOR_232 : USINT := USINT#232; // #808080, rgb(128, 128, 128), Proprietary
 		COLOR_233 : USINT := USINT#233; // #808080, rgb(128, 128, 128), Proprietary
 		COLOR_234 : USINT := USINT#234; // #808080, rgb(128, 128, 128), Proprietary

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_2_E.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_2_E.fbt
@@ -40,7 +40,7 @@
 			<VarDeclaration Name="EDGE2" Type="BOOL" InitialValue="FALSE"/>
 		</InternalVars>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="500" y="385">
+			<ECState Name="STOP" Comment="Initial State" x="500" y="385">
 			</ECState>
 			<ECState Name="TOGGLE1" x="2640" y="1280">
 				<ECAction Algorithm="TOGGLE1" Output="EO"/>
@@ -57,16 +57,16 @@
 			<ECState Name="TOGGLE2" x="2960" y="-240">
 				<ECAction Algorithm="TOGGLE2" Output="EO"/>
 			</ECState>
-			<ECTransition Source="START" Destination="SET1" Condition="SET1" Comment="" x="1140" y="620"/>
-			<ECTransition Source="START" Destination="SET2" Condition="SET2" Comment="" x="1946.67" y="53.33"/>
-			<ECTransition Source="START" Destination="TOGGLE1" Condition="CLK1" Comment="" x="1906.67" y="820"/>
-			<ECTransition Source="START" Destination="TOGGLE2" Condition="CLK2" Comment="" x="1653.33" y="53.33"/>
-			<ECTransition Source="START" Destination="RESET" Condition="R" Comment="" x="1800" y="1506.67"/>
-			<ECTransition Source="TOGGLE1" Destination="START" Condition="1" Comment="" x="1866.67" y="1040"/>
-			<ECTransition Source="SET1" Destination="START" Condition="1" Comment="" x="1140" y="980"/>
-			<ECTransition Source="SET2" Destination="START" Condition="1" Comment="" x="1980" y="273.33"/>
-			<ECTransition Source="TOGGLE2" Destination="START" Condition="1" Comment="" x="1353.33" y="73.33"/>
-			<ECTransition Source="RESET" Destination="START" Condition="1" Comment="" x="1606.67" y="1813.33"/>
+			<ECTransition Source="STOP" Destination="SET1" Condition="SET1" Comment="" x="1140" y="620"/>
+			<ECTransition Source="STOP" Destination="SET2" Condition="SET2" Comment="" x="1946.67" y="53.33"/>
+			<ECTransition Source="STOP" Destination="TOGGLE1" Condition="CLK1" Comment="" x="1906.67" y="820"/>
+			<ECTransition Source="STOP" Destination="TOGGLE2" Condition="CLK2" Comment="" x="1653.33" y="53.33"/>
+			<ECTransition Source="STOP" Destination="RESET" Condition="R" Comment="" x="1800" y="1506.67"/>
+			<ECTransition Source="TOGGLE1" Destination="STOP" Condition="1" Comment="" x="1866.67" y="1040"/>
+			<ECTransition Source="SET1" Destination="STOP" Condition="1" Comment="" x="1140" y="980"/>
+			<ECTransition Source="SET2" Destination="STOP" Condition="1" Comment="" x="1980" y="273.33"/>
+			<ECTransition Source="TOGGLE2" Destination="STOP" Condition="1" Comment="" x="1353.33" y="73.33"/>
+			<ECTransition Source="RESET" Destination="STOP" Condition="1" Comment="" x="1606.67" y="1813.33"/>
 		</ECC>
 		<Algorithm Name="SET1">
 			<ST><![CDATA[ALGORITHM SET1

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_2_E_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_2_E_AX.fbt
@@ -34,7 +34,7 @@
 			<VarDeclaration Name="EDGE2" Type="BOOL" InitialValue="FALSE"/>
 		</InternalVars>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="500" y="385">
+			<ECState Name="STOP" Comment="Initial State" x="500" y="385">
 			</ECState>
 			<ECState Name="TOGGLE1" x="2880" y="1040">
 				<ECAction Algorithm="TOGGLE1" Output="OUT1.E1"/>
@@ -56,16 +56,16 @@
 				<ECAction Algorithm="TOGGLE2" Output="OUT2.E1"/>
 				<ECAction Algorithm="TOGGLE2_2" Output="OUT1.E1"/>
 			</ECState>
-			<ECTransition Source="START" Destination="SET1" Condition="SET1" Comment="" x="1140" y="620"/>
-			<ECTransition Source="START" Destination="SET2" Condition="SET2" Comment="" x="1946.67" y="53.33"/>
-			<ECTransition Source="START" Destination="TOGGLE1" Condition="CLK1" Comment="" x="1906.67" y="820"/>
-			<ECTransition Source="START" Destination="TOGGLE2" Condition="CLK2" Comment="" x="1653.33" y="53.33"/>
-			<ECTransition Source="START" Destination="RESET" Condition="R" Comment="" x="1800" y="1506.67"/>
-			<ECTransition Source="TOGGLE1" Destination="START" Condition="1" Comment="" x="1866.67" y="1040"/>
-			<ECTransition Source="SET1" Destination="START" Condition="1" Comment="" x="1140" y="980"/>
-			<ECTransition Source="SET2" Destination="START" Condition="1" Comment="" x="1980" y="273.33"/>
-			<ECTransition Source="TOGGLE2" Destination="START" Condition="1" Comment="" x="1353.33" y="73.33"/>
-			<ECTransition Source="RESET" Destination="START" Condition="1" Comment="" x="1606.67" y="1813.33"/>
+			<ECTransition Source="STOP" Destination="SET1" Condition="SET1" Comment="" x="1140" y="620"/>
+			<ECTransition Source="STOP" Destination="SET2" Condition="SET2" Comment="" x="1946.67" y="53.33"/>
+			<ECTransition Source="STOP" Destination="TOGGLE1" Condition="CLK1" Comment="" x="1906.67" y="820"/>
+			<ECTransition Source="STOP" Destination="TOGGLE2" Condition="CLK2" Comment="" x="1653.33" y="53.33"/>
+			<ECTransition Source="STOP" Destination="RESET" Condition="R" Comment="" x="1800" y="1506.67"/>
+			<ECTransition Source="TOGGLE1" Destination="STOP" Condition="1" Comment="" x="1866.67" y="1040"/>
+			<ECTransition Source="SET1" Destination="STOP" Condition="1" Comment="" x="1140" y="980"/>
+			<ECTransition Source="SET2" Destination="STOP" Condition="1" Comment="" x="1980" y="273.33"/>
+			<ECTransition Source="TOGGLE2" Destination="STOP" Condition="1" Comment="" x="1353.33" y="73.33"/>
+			<ECTransition Source="RESET" Destination="STOP" Condition="1" Comment="" x="1606.67" y="1813.33"/>
 		</ECC>
 		<Algorithm Name="SET1">
 			<ST><![CDATA[ALGORITHM SET1

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK.fbt
@@ -34,7 +34,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
+			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5120" y="640">
 				<ECAction Algorithm="UP" Output="EO_UP"/>
@@ -42,8 +42,7 @@
 			<ECState Name="DOWN" x="4800" y="1920">
 				<ECAction Algorithm="DOWN" Output="EO_DOWN"/>
 			</ECState>
-			<ECState Name="STOP" x="2800" y="1440">
-			</ECState>
+
 			<ECState Name="UP_STOP" x="5040" y="1280">
 				<ECAction Algorithm="STOP" Output="EO_UP"/>
 			</ECState>
@@ -52,7 +51,6 @@
 			</ECState>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="EI_DOWN[DI_DOWN]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="EI_UP[DI_UP]" Comment="" x="4173.33" y="1020"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="EI_DOWN[NOT DI_DOWN]" Comment="" x="4966.67" y="2306.67"/>
 			<ECTransition Source="UP" Destination="UP_STOP" Condition="EI_UP[NOT DI_UP]" Comment="" x="5146.67" y="1053.33"/>
 			<ECTransition Source="DOWN_STOP" Destination="STOP" Condition="1" Comment="" x="3913.33" y="2120"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_AX.fbt
@@ -18,15 +18,13 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
+			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5120" y="640">
 				<ECAction Algorithm="UP" Output="UP_OUT.E1"/>
 			</ECState>
 			<ECState Name="DOWN" x="4800" y="1920">
 				<ECAction Algorithm="DOWN" Output="DOWN_OUT.E1"/>
-			</ECState>
-			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP_STOP" x="5040" y="1280">
 				<ECAction Algorithm="STOP" Output="UP_OUT.E1"/>
@@ -36,7 +34,6 @@
 			</ECState>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="DOWN_IN.E1[DOWN_IN.D1]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="UP_IN.E1[UP_IN.D1]" Comment="" x="4173.33" y="1020"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="DOWN_IN.E1[NOT DOWN_IN.D1]" Comment="" x="4966.67" y="2306.67"/>
 			<ECTransition Source="UP" Destination="UP_STOP" Condition="UP_IN.E1[NOT UP_IN.D1]" Comment="" x="5146.67" y="1053.33"/>
 			<ECTransition Source="DOWN_STOP" Destination="STOP" Condition="1" Comment="" x="3913.33" y="2120"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_PROTECT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_PROTECT.fbt
@@ -40,7 +40,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
+			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5040" y="720">
 				<ECAction Algorithm="UP" Output="EO_UP"/>
@@ -48,8 +48,7 @@
 			<ECState Name="DOWN" x="4800" y="1920">
 				<ECAction Algorithm="DOWN" Output="EO_DOWN"/>
 			</ECState>
-			<ECState Name="STOP" x="2800" y="1440">
-			</ECState>
+
 			<ECState Name="UP_STOP" x="5040" y="1280">
 				<ECAction Algorithm="STOP" Output="EO_UP"/>
 				<ECAction Output="timeOut.START"/>
@@ -62,7 +61,6 @@
 			</ECState>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="EI_DOWN[DI_DOWN]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="EI_UP[DI_UP]" Comment="" x="4173.33" y="1020"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="EI_DOWN[NOT DI_DOWN]" Comment="" x="4766.67" y="2293.33"/>
 			<ECTransition Source="UP" Destination="UP_STOP" Condition="EI_UP[NOT DI_UP]" Comment="" x="5146.67" y="1053.33"/>
 			<ECTransition Source="UP_STOP" Destination="EVAL" Condition="timeOut.TimeOut" Comment="" x="5273.33" y="1700"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_PROTECT_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_BLOCK_PROTECT_AX.fbt
@@ -27,7 +27,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
+			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5120" y="640">
 				<ECAction Algorithm="UP" Output="UP_OUT.E1"/>
@@ -35,8 +35,7 @@
 			<ECState Name="DOWN" x="4800" y="1920">
 				<ECAction Algorithm="DOWN" Output="DOWN_OUT.E1"/>
 			</ECState>
-			<ECState Name="STOP" x="2800" y="1440">
-			</ECState>
+
 			<ECState Name="UP_STOP" x="5040" y="1280">
 				<ECAction Algorithm="STOP" Output="UP_OUT.E1"/>
 				<ECAction Output="timeOut.START"/>
@@ -49,7 +48,6 @@
 			</ECState>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="DOWN_IN.E1[DOWN_IN.D1]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="UP_IN.E1[UP_IN.D1]" Comment="" x="4173.33" y="1020"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="DOWN_IN.E1[NOT DOWN_IN.D1]" Comment="" x="4766.67" y="2293.33"/>
 			<ECTransition Source="UP" Destination="UP_STOP" Condition="UP_IN.E1[NOT UP_IN.D1]" Comment="" x="5146.67" y="1053.33"/>
 			<ECTransition Source="UP_STOP" Destination="EVAL" Condition="timeOut.TimeOut" Comment="" x="5273.33" y="1700"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_CONFLICT_TRIP.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_CONFLICT_TRIP.fbt
@@ -42,8 +42,6 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
-			</ECState>
 			<ECState Name="STOP" x="2800" y="1440">
 				<ECAction Algorithm="STOP" Output="EO_UP"/>
 				<ECAction Output="EO_DOWN"/>
@@ -60,7 +58,6 @@
 				<ECAction Output="EO_DOWN"/>
 				<ECAction Output="EO_TRIP"/>
 			</ECState>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="EI_UP[DI_UP AND NOT DI_DOWN]" Comment="" x="4173.33" y="1020"/>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="EI_DOWN[DI_DOWN AND NOT DI_UP]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="TRIP" Condition="EI_UP[DI_UP AND DI_DOWN]" Comment="" x="5000" y="1200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_CONFLICT_TRIP_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_CONFLICT_TRIP_AX.fbt
@@ -25,8 +25,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
-			</ECState>
+
 			<ECState Name="STOP" x="2800" y="1440">
 				<ECAction Algorithm="STOP" Output="UP_OUT.E1"/>
 				<ECAction Output="DOWN_OUT.E1"/>
@@ -43,7 +42,6 @@
 				<ECAction Output="DOWN_OUT.E1"/>
 				<ECAction Output="TRIP_OUT.E1"/>
 			</ECState>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="UP_IN.E1[UP_IN.D1 AND NOT DOWN_IN.D1]" Comment="" x="4173.33" y="1020"/>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="DOWN_IN.E1[DOWN_IN.D1 AND NOT UP_IN.D1]" Comment="" x="4133.33" y="1733.33"/>
 			<ECTransition Source="STOP" Destination="TRIP" Condition="UP_IN.E1[UP_IN.D1 AND DOWN_IN.D1]" Comment="" x="5000" y="1200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_RS_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_RS_AX.fbt
@@ -19,14 +19,11 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" x="0" y="0">
-			</ECState>
 			<ECState Name="REQ" x="1000" y="500">
 				<ECAction Algorithm="REQ" Output="Q1.E1"/>
 				<ECAction Output="ILOCK_IN.EI1"/>
 				<ECAction Output="ILOCK_OUT.EO1"/>
 			</ECState>
-			<ECTransition Source="START" Destination="REQ" Condition="1" Comment="" x="500" y="250"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="SET1.E1" Comment="" x="1500" y="200"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="RESET.E1" Comment="" x="1500" y="400"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="ILOCK_IN.EO1" Comment="" x="1500" y="600"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_SR_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_SR_AX.fbt
@@ -19,14 +19,11 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" x="0" y="0">
-			</ECState>
 			<ECState Name="REQ" x="1000" y="500">
 				<ECAction Algorithm="REQ" Output="Q1.E1"/>
 				<ECAction Output="ILOCK_IN.EI1"/>
 				<ECAction Output="ILOCK_OUT.EO1"/>
 			</ECState>
-			<ECTransition Source="START" Destination="REQ" Condition="1" Comment="" x="500" y="250"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="SET1.E1" Comment="" x="220" y="1726.67"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="RESET.E1" Comment="" x="-286.67" y="1220"/>
 			<ECTransition Source="REQ" Destination="REQ" Condition="ILOCK_IN.EO1" Comment="" x="1420" y="1780"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH.fbt
@@ -34,7 +34,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
+			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5040" y="720">
 				<ECAction Algorithm="UP" Output="EO_UP"/>
@@ -44,8 +44,7 @@
 				<ECAction Algorithm="DOWN" Output="EO_DOWN"/>
 				<ECAction Output="EO_UP"/>
 			</ECState>
-			<ECState Name="STOP" x="2800" y="1440">
-			</ECState>
+
 			<ECState Name="UP_STOP" x="5040" y="1280">
 				<ECAction Algorithm="STOP" Output="EO_UP"/>
 			</ECState>
@@ -62,7 +61,6 @@
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="EI_DOWN[NOT DI_DOWN AND NOT DI_UP]" Comment="" x="5473.33" y="2306.67"/>
 			<ECTransition Source="UP_STOP" Destination="STOP" Condition="1" Comment="" x="4133.33" y="1313.33"/>
 			<ECTransition Source="DOWN_STOP" Destination="STOP" Condition="1" Comment="" x="3913.33" y="2120"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2986.67" y="1060"/>
 		</ECC>
 		<Algorithm Name="UP">
 			<ST><![CDATA[DO_UP := BOOL#TRUE;

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_AX.fbt
@@ -18,8 +18,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
-			</ECState>
+
 			<ECState Name="UP" x="5040" y="720">
 				<ECAction Algorithm="UP" Output="UP_OUT.E1"/>
 				<ECAction Output="DOWN_OUT.E1"/>
@@ -46,7 +45,6 @@
 			<ECTransition Source="DOWN" Destination="DOWN_STOP" Condition="DOWN_IN.E1[NOT DOWN_IN.D1 AND NOT UP_IN.D1]" Comment="" x="5473.33" y="2306.67"/>
 			<ECTransition Source="UP_STOP" Destination="STOP" Condition="1" Comment="" x="4133.33" y="1313.33"/>
 			<ECTransition Source="DOWN_STOP" Destination="STOP" Condition="1" Comment="" x="3913.33" y="2120"/>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2986.67" y="1060"/>
 		</ECC>
 		<Algorithm Name="UP">
 			<ST><![CDATA[UP_OUT.D1 := BOOL#TRUE;

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_PROTECT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_PROTECT.fbt
@@ -40,8 +40,7 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
-			</ECState>
+
 			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5120" y="640">
@@ -59,7 +58,6 @@
 			</ECState>
 			<ECState Name="EVAL" x="7600" y="1520">
 			</ECState>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="EI_UP[DI_UP]" Comment="" x="4173.33" y="1020"/>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="EI_DOWN[DI_DOWN]" Comment="" x="3333.33" y="2133.33"/>
 			<ECTransition Source="UP" Destination="PROTECT" Condition="EI_UP[NOT DI_UP]" Comment="" x="5333.33" y="1066.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_PROTECT_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_SWITCH_PROTECT_AX.fbt
@@ -27,8 +27,6 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="START" Comment="Initial State" x="2960" y="560">
-			</ECState>
 			<ECState Name="STOP" x="2800" y="1440">
 			</ECState>
 			<ECState Name="UP" x="5120" y="640">
@@ -46,7 +44,6 @@
 			</ECState>
 			<ECState Name="EVAL" x="7600" y="1520">
 			</ECState>
-			<ECTransition Source="START" Destination="STOP" Condition="1" Comment="" x="2953.33" y="1226.67"/>
 			<ECTransition Source="STOP" Destination="UP" Condition="UP_IN.E1[UP_IN.D1]" Comment="" x="4173.33" y="1020"/>
 			<ECTransition Source="STOP" Destination="DOWN" Condition="DOWN_IN.E1[DOWN_IN.D1]" Comment="" x="3333.33" y="2133.33"/>
 			<ECTransition Source="UP" Destination="PROTECT" Condition="UP_IN.E1[NOT UP_IN.D1]" Comment="" x="5333.33" y="1066.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_001d2_AX.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_001d2_AX.SUB
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_001d2_AX" Comment="DigitalInput_I1/2 auf DigitalOutput_Q1/2, als Alternative(Verriegelt) mit Plug and Socket, ohne ECC">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="logiBUS::io::DI::logiBUS_DI::Input_I1"/>
+		<Import declaration="logiBUS::io::DI::logiBUS_DI::Input_I2"/>
+		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q1"/>
+		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q2"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="DigitalInput_I1" Type="logiBUS::io::DI::logiBUS_IXA" x="-4700" y="-600">
+			<Parameter Name="QI" Value="TRUE">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="PARAMS" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="Input" Value="Input_I1"/>
+			<Parameter Name="QO" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+		</FB>
+		<FB Name="DigitalOutput_Q1" Type="logiBUS::io::DQ::logiBUS_QXA" x="2400" y="-600">
+			<Parameter Name="QI" Value="TRUE">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="PARAMS" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="Output" Value="Output_Q1"/>
+			<Parameter Name="QO" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+		</FB>
+		<FB Name="AX_AND_2_Q1" Type="adapter::booleanOperators::AX_AND_2" x="-1900" y="-300">
+		</FB>
+		<FB Name="DigitalOutput_Q2" Type="logiBUS::io::DQ::logiBUS_QXA" x="2500" y="1100">
+			<Parameter Name="QI" Value="TRUE">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="PARAMS" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="Output" Value="Output_Q2"/>
+			<Parameter Name="QO" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+		</FB>
+		<FB Name="AX_AND_2_Q2" Type="adapter::booleanOperators::AX_AND_2" x="-1900" y="1300">
+		</FB>
+		<FB Name="DigitalInput_I2" Type="logiBUS::io::DI::logiBUS_IXA" x="-4800" y="1100">
+			<Parameter Name="QI" Value="TRUE">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="PARAMS" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+			<Parameter Name="Input" Value="Input_I2"/>
+			<Parameter Name="QO" Value="">
+				<Attribute Name="Visible" Value="false"/>
+			</Parameter>
+		</FB>
+		<FB Name="AX_SPLIT_2_Q1" Type="adapter::events::unidirectional::AX_SPLIT_2" x="-900" y="-300">
+		</FB>
+		<FB Name="AX_SPLIT_2_Q2" Type="adapter::events::unidirectional::AX_SPLIT_2" x="-900" y="1300">
+		</FB>
+		<FB Name="AX_NOT_INIT_Q1" Type="adapter::booleanOperators::AX_NOT_INIT" x="200" y="100">
+		</FB>
+		<FB Name="AX_NOT_INIT_Q2" Type="adapter::booleanOperators::AX_NOT_INIT" x="200" y="900">
+		</FB>
+		<FB Name="AX_D_FF_Q1" Type="adapter::events::unidirectional::AX_D_FF" x="1200" y="200">
+		</FB>
+		<FB Name="AX_D_FF_Q2" Type="adapter::events::unidirectional::AX_D_FF" x="1200" y="1000">
+		</FB>
+		<Comment Comment="Kompliziert. &#10;&#10;BESSER: ILOCK-Baustein" x="-1900" y="2000" width="1000" height="500"/>
+		<AdapterConnections>
+			<Connection Source="AX_AND_2_Q1.OUT" Destination="AX_SPLIT_2_Q1.IN"/>
+			<Connection Source="AX_AND_2_Q2.OUT" Destination="AX_SPLIT_2_Q2.IN"/>
+			<Connection Source="AX_SPLIT_2_Q1.OUT2" Destination="AX_NOT_INIT_Q1.IN" dx1="173.33"/>
+			<Connection Source="AX_SPLIT_2_Q2.OUT1" Destination="AX_NOT_INIT_Q2.IN" dx1="173.33"/>
+			<Connection Source="DigitalInput_I2.IN" Destination="AX_AND_2_Q2.IN2" dx1="1046.67"/>
+			<Connection Source="AX_SPLIT_2_Q2.OUT2" Destination="DigitalOutput_Q2.OUT" dx1="1320"/>
+			<Connection Source="AX_SPLIT_2_Q1.OUT1" Destination="DigitalOutput_Q1.OUT" dx1="1273.33"/>
+			<Connection Source="DigitalInput_I1.IN" Destination="AX_AND_2_Q1.IN1" dx1="1000"/>
+			<Connection Source="AX_NOT_INIT_Q2.OUT" Destination="AX_D_FF_Q2.I" dx1="100"/>
+			<Connection Source="AX_NOT_INIT_Q1.OUT" Destination="AX_D_FF_Q1.I" dx1="100"/>
+			<Connection Source="AX_D_FF_Q1.Q" Destination="AX_AND_2_Q2.IN1" dx1="433.33" dx2="80" dy="340"/>
+			<Connection Source="AX_D_FF_Q2.Q" Destination="AX_AND_2_Q1.IN2" dx1="80" dx2="80" dy="-593.33"/>
+		</AdapterConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_201_AX.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_201_AX.SUB
@@ -21,7 +21,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I2"/>
 		</FB>
-		<FB Name="ILOCK_AX" Type="logiBUS::signalprocessing::interlock::ILOCK_BLOCK_AX" x="-2300" y="-300">
+		<FB Name="ILOCK_BLOCK_AX" Type="logiBUS::signalprocessing::interlock::ILOCK_BLOCK_AX" x="-2300" y="-300">
 		</FB>
 		<FB Name="DigitalOutput_Q1" Type="logiBUS::io::DQ::logiBUS_QXA" x="200" y="-1000">
 			<Parameter Name="QI" Value="TRUE"/>
@@ -32,10 +32,10 @@
 			<Parameter Name="Output" Value="Output_Q2"/>
 		</FB>
 		<AdapterConnections>
-			<Connection Source="DigitalInput_I1.IN" Destination="ILOCK_AX.UP_IN" dx1="200"/>
-			<Connection Source="DigitalInput_I2.IN" Destination="ILOCK_AX.DOWN_IN" dx1="200"/>
-			<Connection Source="ILOCK_AX.UP_OUT" Destination="DigitalOutput_Q1.OUT" dx1="200"/>
-			<Connection Source="ILOCK_AX.DOWN_OUT" Destination="DigitalOutput_Q2.OUT" dx1="200"/>
+			<Connection Source="DigitalInput_I1.IN" Destination="ILOCK_BLOCK_AX.UP_IN" dx1="200"/>
+			<Connection Source="DigitalInput_I2.IN" Destination="ILOCK_BLOCK_AX.DOWN_IN" dx1="200"/>
+			<Connection Source="ILOCK_BLOCK_AX.UP_OUT" Destination="DigitalOutput_Q1.OUT" dx1="200"/>
+			<Connection Source="ILOCK_BLOCK_AX.DOWN_OUT" Destination="DigitalOutput_Q2.OUT" dx1="200"/>
 		</AdapterConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/test_AX.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/test_AX.sys
@@ -9,7 +9,7 @@
 	</CompilerInfo>
 	<Application Name="App_AX" Comment="Default App for Everything">
 		<SubAppNetwork>
-			<SubApp Name="Control" Type="Uebungen::Uebung_028c_AR" x="3100" y="0">
+			<SubApp Name="Control" Type="Uebungen::Uebung_201_AX" x="3100" y="0">
 			</SubApp>
 		</SubAppNetwork>
 	</Application>


### PR DESCRIPTION
This update modifies several interlock function block files by changing the initial state name from "START" to "STOP." This alteration aligns the state naming convention across various files and potentially clarifies the function block's logic flow. Additionally, a new exercise file Uebung_001d2_AX.SUB is added, and Uebung_201_AX.SUB is updated to reflect consistent naming in the control application.

## Summary by Sourcery

Align interlock function block state naming and update associated AX exercises and configuration.

New Features:
- Add new AX exercise file Uebung_001d2_AX.SUB.

Enhancements:
- Rename the initial state from START to STOP across multiple interlock function block (ILOCK) variants for consistent state management.
- Update existing AX exercise Uebung_201_AX.SUB to reflect the revised interlock state naming.

Tests:
- Adjust AX test/configuration system definition test_AX.sys to reference the updated exercises and interlock blocks where required.