### PR TITLE
Add FIELDBUS_WORD_TO_SIGNAL FB for signal validation and output mirroring

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL.fbt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="FIELDBUS_BYTE_TO_SIGNAL" Comment="Mirrors IN-&gt;OUT if Signal Valid. ">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-30">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+				<With Var="VALID"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Input" InitialValue="NOT_AVAILABLE_B"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Output Filtered" InitialValue="16#00"/>
+			<VarDeclaration Name="VALID" Type="BOOL" Comment="TRUE if Signal is VALID" InitialValue="FALSE"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ" Comment="Executed algorithm">
+			<ST><![CDATA[
+
+IF (IN <= VALID_SIGNAL_B) THEN
+	OUT := IN;
+	VALID := BOOL#TRUE;
+ELSE
+	OUT := BYTE#0;
+	VALID := BOOL#FALSE;
+END_IF;
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL.fbt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="FIELDBUS_DWORD_TO_SIGNAL" Comment="Mirrors IN-&gt;OUT if Signal Valid. ">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-30">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DM"/>
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+				<With Var="VALID"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="DWORD" Comment="Input" InitialValue="NOT_AVAILABLE_DM"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="DWORD" Comment="Output Filtered" InitialValue="16#00000000"/>
+			<VarDeclaration Name="VALID" Type="BOOL" Comment="TRUE if Signal is VALID" InitialValue="FALSE"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ" Comment="Executed algorithm">
+			<ST><![CDATA[
+
+IF (IN <= VALID_SIGNAL_DW) THEN
+	OUT := IN;
+	VALID := BOOL#TRUE;
+ELSE
+	OUT := DWORD#0;
+	VALID := BOOL#FALSE;
+END_IF;
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="FIELDBUS_QUARTER_TO_SIGNAL" Comment="Mirrors IN-&gt;OUT if Signal Valid. ">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-30">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::DONT_CARE_2bit"/>
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_2Bit"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+				<With Var="VALID"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Input" InitialValue="NOT_AVAILABLE_2Bit"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="BYTE" Comment="Output Filtered" InitialValue="16#00"/>
+			<VarDeclaration Name="VALID" Type="BOOL" Comment="TRUE if Signal is VALID" InitialValue="FALSE"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ" Comment="Executed algorithm">
+			<ST><![CDATA[
+
+IF (IN < DONT_CARE_2bit) THEN
+	OUT := IN;
+	VALID := BOOL#TRUE;
+ELSE
+	OUT := BYTE#0;
+	VALID := BOOL#FALSE;
+END_IF;
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL.fbt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="FIELDBUS_WORD_TO_SIGNAL" Comment="Mirrors IN-&gt;OUT if Signal Valid. ">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-05-30">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+				<With Var="IN"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="OUT"/>
+				<With Var="VALID"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="IN" Type="WORD" Comment="Input" InitialValue="NOT_AVAILABLE_WM"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="OUT" Type="WORD" Comment="Output Filtered" InitialValue="16#0000"/>
+			<VarDeclaration Name="VALID" Type="BOOL" Comment="TRUE if Signal is VALID" InitialValue="FALSE"/>
+		</OutputVars>
+	</InterfaceList>
+	<SimpleFB>
+		<ECState Name="REQ">
+			<ECAction Algorithm="REQ" Output="CNF"/>
+		</ECState>
+		<Algorithm Name="REQ" Comment="Executed algorithm">
+			<ST><![CDATA[
+
+IF (IN <= VALID_SIGNAL_W) THEN
+	OUT := IN;
+	VALID := BOOL#TRUE;
+ELSE
+	OUT := WORD#0;
+	VALID := BOOL#FALSE;
+END_IF;
+
+]]></ST>
+		</Algorithm>
+	</SimpleFB>
+</FBType>


### PR DESCRIPTION
Introduce a new function block that mirrors the input to output when the signal is valid. The block checks if the input signal is valid and sets the corresponding output and validity accordingly.

## Summary by Sourcery

New Features:
- Introduce the FIELDBUS_WORD_TO_SIGNAL function block to propagate fieldbus word inputs to outputs only when the signal is valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new signal validation function blocks for fieldbus signal processing, supporting BYTE, DWORD, QUARTER, and WORD data types. These blocks validate input signals against predefined thresholds and provide output values along with validation status indicators for improved signal handling reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Meisterschulen-am-Ostbahnhof-Munchen/4diac_training1/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->