### PR TITLE
Add aliasing for CNumberVariable objects in JOP parsing

### DIFF
--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -167,11 +167,11 @@ def readJOP(jop_filepath):
                     # If multiple objects point to the same variable, prefer the one with the smaller
                     # scale factor (usually the base SI unit or the highest precision).
                     if alias_name not in result:
-                        result[alias_name] = info.copy()
+                        result[alias_name] = info
                     else:
                         current_scale = result[alias_name]["scale"]
                         if scale < current_scale:
-                            result[alias_name] = info.copy()
+                            result[alias_name] = info
 
     return result
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -94,6 +94,15 @@ def readIOPH(filepaths):
     renamed = {rename_map.get(name, name): value for name, value in definitions.items()}
     return renamed, rename_map
 
+def create_numeric_info(obj_id, scale, offset, decimals):
+    """Factory to create a numeric info dictionary."""
+    return {
+        "id":       obj_id,
+        "scale":    scale,
+        "offset":   offset,
+        "decimals": decimals,
+    }
+
 def readJOP(jop_filepath):
     """Parse a JetViewSoft .jop XML file and extract InputNumber and OutputNumber objects.
 
@@ -103,7 +112,7 @@ def readJOP(jop_filepath):
     tree = ET.parse(jop_filepath)
     root = tree.getroot()
 
-    # Pre-scan for CNumberVariable objects and primary object names
+    # Pre-scan for names to avoid alias collisions
     var_names = {}
     primary_names = set()
     for obj in root.iter("Object"):
@@ -115,8 +124,7 @@ def readJOP(jop_filepath):
                 var_names[v_id] = v_name
         elif cls in ("CInputNumber", "COutputNumber"):
             name = obj.get("ObjectName")
-            jvs_id = obj.get("JVS-ID")
-            if name and jvs_id:
+            if name:
                 primary_names.add(name)
 
     result = {}
@@ -144,12 +152,7 @@ def readJOP(jop_filepath):
         offset   = int(props.get("Offset", "0"))
         decimals = int(props.get("NoOfDecimals", "0"))
 
-        info = {
-            "id":       obj_id,
-            "scale":    scale,
-            "offset":   offset,
-            "decimals": decimals,
-        }
+        info = create_numeric_info(obj_id, scale, offset, decimals)
         result[name] = info
 
         # Alias logic: if this object references a NumberVariable, create an alias.
@@ -162,16 +165,19 @@ def readJOP(jop_filepath):
                     continue
                 if child_id in var_names:
                     alias_name = var_names[child_id]
+                    # Protect primary object names from being overwritten by aliases.
                     if alias_name in primary_names:
                         continue
+                    
                     # If multiple objects point to the same variable, prefer the one with the smaller
                     # scale factor (usually the base SI unit or the highest precision).
                     if alias_name not in result:
-                        result[alias_name] = info
+                        result[alias_name] = create_numeric_info(obj_id, scale, offset, decimals)
                     else:
+                        # We only overwrite if it's already an alias (guaranteed by the check above).
                         current_scale = result[alias_name]["scale"]
                         if scale < current_scale:
-                            result[alias_name] = info
+                            result[alias_name] = create_numeric_info(obj_id, scale, offset, decimals)
 
     return result
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -103,6 +103,15 @@ def readJOP(jop_filepath):
     tree = ET.parse(jop_filepath)
     root = tree.getroot()
 
+    # Pre-scan for CNumberVariable objects to use as aliases
+    var_names = {}
+    for obj in root.iter("Object"):
+        if obj.get("Class") == "CNumberVariable":
+            v_id = obj.get("JVS-ID")
+            v_name = obj.get("ObjectName")
+            if v_id and v_name:
+                var_names[v_id] = v_name
+
     result = {}
 
     for obj in root.iter("Object"):
@@ -128,12 +137,28 @@ def readJOP(jop_filepath):
         offset   = int(props.get("Offset", "0"))
         decimals = int(props.get("NoOfDecimals", "0"))
 
-        result[name] = {
+        info = {
             "id":       obj_id,
             "scale":    scale,
             "offset":   offset,
             "decimals": decimals,
         }
+        result[name] = info
+
+        # Alias logic: if this object references a NumberVariable, create an alias
+        objs_elem = obj.find("Objects")
+        if objs_elem is not None:
+            for child_obj in objs_elem.findall("Object"):
+                child_id = child_obj.get("JVS-ID")
+                if child_id in var_names:
+                    alias_name = var_names[child_id]
+                    # If multiple objects point to the same variable, prefer the one with the smaller scale factor
+                    if alias_name not in result:
+                        result[alias_name] = info
+                    else:
+                        current_scale = result[alias_name]["scale"]
+                        if scale < current_scale:
+                            result[alias_name] = info
 
     return result
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -111,11 +111,14 @@ def readJOP(jop_filepath):
     """
     tree = ET.parse(jop_filepath)
     root = tree.getroot()
+    objects_container = root.find("Objects")
+    if objects_container is None:
+        return {}
 
     # Pre-scan for names to avoid alias collisions
     var_names = {}
     primary_names = set()
-    for obj in root.iter("Object"):
+    for obj in objects_container.findall("Object"):
         cls = obj.get("Class")
         if cls == "CNumberVariable":
             v_id = obj.get("JVS-ID")
@@ -129,7 +132,7 @@ def readJOP(jop_filepath):
 
     result = {}
 
-    for obj in root.iter("Object"):
+    for obj in objects_container.findall("Object"):
         cls = obj.get("Class")
         if cls not in ("CInputNumber", "COutputNumber"):
             continue

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -170,14 +170,15 @@ def readJOP(jop_filepath):
                         continue
                     
                     # If multiple objects point to the same variable, prefer the one with the smaller
-                    # scale factor (usually the base SI unit or the highest precision).
+                    # absolute scale factor (usually the base SI unit or the highest precision).
                     # The alias should use the ID of the NumberVariable itself (child_id).
                     alias_id = int(child_id)
                     if alias_name not in result:
                         result[alias_name] = create_numeric_info(alias_id, scale, offset, decimals)
                     else:
+                        # Compare absolute values to correctly handle negative scales.
                         current_scale = result[alias_name]["scale"]
-                        if scale < current_scale:
+                        if abs(scale) < abs(current_scale):
                             result[alias_name] = create_numeric_info(alias_id, scale, offset, decimals)
 
     return result
@@ -241,7 +242,8 @@ def writeGCFfile(data, filepaths):
 
 def _format_real(value):
     """Format a float as an IEC 61131-3 REAL literal (no scientific notation)."""
-    s = f"{float(value):.10f}".rstrip('0')
+    val = float(value)
+    s = f"{val:.10f}".rstrip('0')
     if s.endswith('.'):
         s += '0'
     return s

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -171,13 +171,14 @@ def readJOP(jop_filepath):
                     
                     # If multiple objects point to the same variable, prefer the one with the smaller
                     # scale factor (usually the base SI unit or the highest precision).
+                    # The alias should use the ID of the NumberVariable itself (child_id).
+                    alias_id = int(child_id)
                     if alias_name not in result:
-                        result[alias_name] = create_numeric_info(obj_id, scale, offset, decimals)
+                        result[alias_name] = create_numeric_info(alias_id, scale, offset, decimals)
                     else:
-                        # We only overwrite if it's already an alias (guaranteed by the check above).
                         current_scale = result[alias_name]["scale"]
                         if scale < current_scale:
-                            result[alias_name] = create_numeric_info(obj_id, scale, offset, decimals)
+                            result[alias_name] = create_numeric_info(alias_id, scale, offset, decimals)
 
     return result
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -156,8 +156,10 @@ def readJOP(jop_filepath):
         if objs_elem is not None:
             for child_obj in objs_elem.findall("Object"):
                 child_id = child_obj.get("JVS-ID")
-                if child_id in var_names:
+                if child_id and child_id in var_names:
                     alias_name = var_names[child_id]
+                    if alias_name in primary_names:
+                        continue
                     # If multiple objects point to the same variable, prefer the one with the smaller scale factor
                     if alias_name not in result:
                         result[alias_name] = info

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -151,22 +151,26 @@ def readJOP(jop_filepath):
         }
         result[name] = info
 
-        # Alias logic: if this object references a NumberVariable, create an alias
+        # Alias logic: if this object references a NumberVariable, create an alias.
+        # This allows writing to the variable name directly in the application.
         objs_elem = obj.find("Objects")
         if objs_elem is not None:
             for child_obj in objs_elem.findall("Object"):
                 child_id = child_obj.get("JVS-ID")
-                if child_id and child_id in var_names:
+                if not child_id:
+                    continue
+                if child_id in var_names:
                     alias_name = var_names[child_id]
                     if alias_name in primary_names:
                         continue
-                    # If multiple objects point to the same variable, prefer the one with the smaller scale factor
+                    # If multiple objects point to the same variable, prefer the one with the smaller
+                    # scale factor (usually the base SI unit or the highest precision).
                     if alias_name not in result:
-                        result[alias_name] = info
+                        result[alias_name] = info.copy()
                     else:
                         current_scale = result[alias_name]["scale"]
                         if scale < current_scale:
-                            result[alias_name] = info
+                            result[alias_name] = info.copy()
 
     return result
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -115,7 +115,8 @@ def readJOP(jop_filepath):
                 var_names[v_id] = v_name
         elif cls in ("CInputNumber", "COutputNumber"):
             name = obj.get("ObjectName")
-            if name:
+            jvs_id = obj.get("JVS-ID")
+            if name and jvs_id:
                 primary_names.add(name)
 
     result = {}

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -103,14 +103,20 @@ def readJOP(jop_filepath):
     tree = ET.parse(jop_filepath)
     root = tree.getroot()
 
-    # Pre-scan for CNumberVariable objects to use as aliases
+    # Pre-scan for CNumberVariable objects and primary object names
     var_names = {}
+    primary_names = set()
     for obj in root.iter("Object"):
-        if obj.get("Class") == "CNumberVariable":
+        cls = obj.get("Class")
+        if cls == "CNumberVariable":
             v_id = obj.get("JVS-ID")
             v_name = obj.get("ObjectName")
             if v_id and v_name:
                 var_names[v_id] = v_name
+        elif cls in ("CInputNumber", "COutputNumber"):
+            name = obj.get("ObjectName")
+            if name:
+                primary_names.add(name)
 
     result = {}
 

--- a/Ventilsteuerung/scripts/GcfScript.py
+++ b/Ventilsteuerung/scripts/GcfScript.py
@@ -152,6 +152,8 @@ def readJOP(jop_filepath):
         offset   = int(props.get("Offset", "0"))
         decimals = int(props.get("NoOfDecimals", "0"))
 
+        # The alias uses the parent object's scale/offset/decimals, since
+        # CNumberVariable itself carries no scaling properties.
         info = create_numeric_info(obj_id, scale, offset, decimals)
         result[name] = info
 
@@ -167,6 +169,11 @@ def readJOP(jop_filepath):
                     alias_name = var_names[child_id]
                     # Protect primary object names from being overwritten by aliases.
                     if alias_name in primary_names:
+                        print(f"  Skip alias '{alias_name}': conflicts with primary object name")
+                        continue
+                    
+                    # Guard against physically meaningless zero scales.
+                    if scale == 0.0:
                         continue
                     
                     # If multiple objects point to the same variable, prefer the one with the smaller
@@ -179,6 +186,7 @@ def readJOP(jop_filepath):
                         # Compare absolute values to correctly handle negative scales.
                         current_scale = result[alias_name]["scale"]
                         if abs(scale) < abs(current_scale):
+                            print(f"  Update alias '{alias_name}': scale {current_scale} -> {scale}")
                             result[alias_name] = create_numeric_info(alias_id, scale, offset, decimals)
 
     return result


### PR DESCRIPTION
Introduce a mechanism to create aliases based on CNumberVariable objects during JOP file parsing, allowing objects to be referenced by their variable names. This enhances usability by supporting variable-based referencing.

## Summary by Sourcery

Add support for aliasing numeric I/O objects by associated CNumberVariable names when parsing JOP files.

Enhancements:
- Introduce a helper factory to build numeric info dictionaries for parsed objects.
- Pre-scan JOP XML for CNumberVariable and primary I/O names to safely create non-colliding aliases.
- Create variable-name-based aliases for numeric input/output objects, preferring aliases with smaller scale factors when multiple mappings exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configuration variable handling has been enhanced with improved mapping and aliasing support. Variable references are now processed with greater consistency, ensuring more robust data resolution during configuration file reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->