### PR TITLE
Adds new TECU exercises and variables for MSS and WBSD

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070_AUI.SUB
@@ -18,9 +18,6 @@
 		</FB>
 		<FB Name="CONV_AUI_AUDI" Type="adapter::conversion::unidirectional::AUI_TO_AUDI" x="100" y="1900">
 		</FB>
-		<EventConnections>
-			<Connection Source="IA_WBSD.INITO" Destination="Q_NumericValue_WBSD.INIT" dx1="1726.67"/>
-		</EventConnections>
 		<AdapterConnections>
 			<Connection Source="IA_WBSD.SPEED" Destination="CONV_AUI_AUDI.AUI_IN" dx1="533.33"/>
 			<Connection Source="CONV_AUI_AUDI.AUDI_OUT" Destination="Q_NumericValue_WBSD.u32NewValue" dx1="1166.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070c_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070c_AUI.SUB
@@ -10,25 +10,19 @@
 	<SubAppInterfaceList>
 	</SubAppInterfaceList>
 	<SubAppNetwork>
-		<FB Name="IA_WBSD" Type="isobus::tecu::IA_WBSD" x="-1200" y="900">
+		<FB Name="IA_WBSD" Type="isobus::tecu::IA_WBSD" x="-1200" y="1000">
 			<Parameter Name="QI" Value="TRUE"/>
 		</FB>
-		<FB Name="CONV_AUI_AUDI" Type="adapter::conversion::unidirectional::AUI_TO_AUDI" x="300" y="1300">
-		</FB>
-		<FB Name="FIELDBUS_UDINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::AUDI_FIELDBUS_UDINT_TO_SIGNAL_SCALED" x="1100" y="1200">
-			<Parameter Name="SCALE" Value="LREAL#0.001"/>
+		<FB Name="FIELDBUS_UDINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_SCALED" x="900" y="1000">
+			<Parameter Name="SCALE" Value="REAL#0.001"/>
 			<Parameter Name="OFFSET" Value="DINT#0"/>
 		</FB>
-		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA_LREAL" x="3200" y="1400">
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5200" y="900">
 			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
 		</FB>
-		<EventConnections>
-			<Connection Source="IA_WBSD.INITO" Destination="Q_NumericValue.INIT" dx1="66.67"/>
-		</EventConnections>
 		<AdapterConnections>
-			<Connection Source="IA_WBSD.SPEED" Destination="CONV_AUI_AUDI.AUI_IN" dx1="66.67"/>
-			<Connection Source="CONV_AUI_AUDI.AUDI_OUT" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.IN" dx1="66.67"/>
-			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.lrPhys" dx1="66.67"/>
+			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.rPhys" dx1="66.67"/>
+			<Connection Source="IA_WBSD.SPEED" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.IN"/>
 		</AdapterConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070c_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_070c_AUI.SUB
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_070c_AUI" Comment="WBSD auf UT ausgeben (Adapter Version)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-06-01" Remarks="WBSD mit Compound Scaling (Adapter Version)">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="IA_WBSD" Type="isobus::tecu::IA_WBSD" x="-1200" y="900">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="CONV_AUI_AUDI" Type="adapter::conversion::unidirectional::AUI_TO_AUDI" x="300" y="1300">
+		</FB>
+		<FB Name="FIELDBUS_UDINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::AUDI_FIELDBUS_UDINT_TO_SIGNAL_SCALED" x="1100" y="1200">
+			<Parameter Name="SCALE" Value="LREAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA_LREAL" x="3200" y="1400">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<EventConnections>
+			<Connection Source="IA_WBSD.INITO" Destination="Q_NumericValue.INIT" dx1="66.67"/>
+		</EventConnections>
+		<AdapterConnections>
+			<Connection Source="IA_WBSD.SPEED" Destination="CONV_AUI_AUDI.AUI_IN" dx1="66.67"/>
+			<Connection Source="CONV_AUI_AUDI.AUDI_OUT" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.IN" dx1="66.67"/>
+			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.lrPhys" dx1="66.67"/>
+		</AdapterConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_072c_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_072c_AUI.SUB
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_072c_AUI" Comment="GBSD und WBSD auf UT ausgeben mit PHYS (Adapter Version)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-06-01" Remarks="GBSD und WBSD mit PHYS Skalierung (Adapter Version)">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Ground_based_machine_speed"/>
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="IA_GBSD" Type="isobus::tecu::IA_GBSD" x="-1200" y="400">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="IA_WBSD" Type="isobus::tecu::IA_WBSD" x="-1200" y="1700">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_SCALED" x="800" y="400">
+			<Parameter Name="SCALE" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED_WBSD" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_SCALED" x="800" y="1700">
+			<Parameter Name="SCALE" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="Q_NumericValue_GBSD" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5100" y="300">
+			<Parameter Name="stObj" Value="NumberVariable_Ground_based_machine_speed"/>
+		</FB>
+		<FB Name="Q_NumericValue_WBSD" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5100" y="1600">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<AdapterConnections>
+			<Connection Source="IA_GBSD.SPEED" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD.IN" dx1="66.67"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD.OUT" Destination="Q_NumericValue_GBSD.rPhys" dx1="66.67"/>
+			<Connection Source="IA_WBSD.SPEED" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED_WBSD.IN"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED_WBSD.OUT" Destination="Q_NumericValue_WBSD.rPhys" dx1="1213.33"/>
+		</AdapterConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_073_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_073_AUI.SUB
@@ -16,11 +16,8 @@
 		<FB Name="Q_NumericValue_VDS" Type="isobus::UT::Q::Q_NumericValue_AUDI" x="1400" y="500">
 			<Parameter Name="u16ObjId" Value="NumberVariable_Wheel_based_machine_speed"/>
 		</FB>
-		<FB Name="CONV_VDS" Type="adapter::conversion::unidirectional::AUI_TO_AUDI" x="-500" y="500">
+		<FB Name="CONV_VDS" Type="adapter::conversion::unidirectional::AUI_TO_AUDI" x="-1600" y="900">
 		</FB>
-		<EventConnections>
-			<Connection Source="IA_VDS.INITO" Destination="Q_NumericValue_VDS.INIT" dx1="500"/>
-		</EventConnections>
 		<AdapterConnections>
 			<Connection Source="IA_VDS.NAV_SPEED" Destination="CONV_VDS.AUI_IN" dx1="200"/>
 			<Connection Source="CONV_VDS.AUDI_OUT" Destination="Q_NumericValue_VDS.u32NewValue" dx1="200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_073c_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_073c_AUI.SUB
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_073c_AUI" Comment="VDS und GBSD auf UT ausgeben mit PHYS (Adapter Version)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-06-01" Remarks="VDS und GBSD mit PHYS Skalierung (Adapter Version)">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Ground_based_machine_speed"/>
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="IA_GBSD" Type="isobus::tecu::IA_GBSD" x="-1200" y="400">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="IA_VDS" Type="isobus::tecu::IA_VDS" x="-1200" y="1700">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_SCALED" x="800" y="400">
+			<Parameter Name="SCALE" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED_VDS" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_SCALED" x="800" y="1700">
+			<Parameter Name="SCALE" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="Q_NumericValue_GBSD" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5100" y="300">
+			<Parameter Name="stObj" Value="NumberVariable_Ground_based_machine_speed"/>
+		</FB>
+		<FB Name="Q_NumericValue_VDS" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5100" y="1600">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<Comment Comment="TODO: &#10;NumberVariable_Navigation_based_vehicle_speed&#10;im Object Pool anlegen, und hier umändern.&#10;&#10;solange verwenden wir hier NumberVariable_Wheel_based_machine_speed ersatzweise" x="2700" y="2700" width="3100" height="700"/>
+		<AdapterConnections>
+			<Connection Source="IA_GBSD.SPEED" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD.IN"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED_GBSD.OUT" Destination="Q_NumericValue_GBSD.rPhys" dx1="66.67"/>
+			<Connection Source="IA_VDS.NAV_SPEED" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED_VDS.IN"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED_VDS.OUT" Destination="Q_NumericValue_VDS.rPhys" dx1="1160"/>
+		</AdapterConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_076_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_076_AUI.SUB
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_076_AUI" Comment="MSS mit Compound Scaling auf UT ausgeben (Adapter Version)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-06-01" Remarks="MSS Machine Selected Speed mit Compound Scaling (Adapter Version)">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="IA_MSS" Type="isobus::tecu::IA_MSS" x="-1200" y="900">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="1100" y="1200">
+			<Parameter Name="SCALE_HIGH" Value="REAL#0.256"/>
+			<Parameter Name="SCALE_LOW" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5500" y="900">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<Comment Comment="TODO: &#10;NumberVariable_Machine_selected_speed&#10;im Object Pool anlegen, und hier umändern.&#10;&#10;solange verwenden wir hier NumberVariable_Wheel_based_machine_speed ersatzweise" x="3600" y="2000" width="3100" height="700"/>
+		<EventConnections>
+			<Connection Source="IA_MSS.INITO" Destination="Q_NumericValue.INIT"/>
+		</EventConnections>
+		<AdapterConnections>
+			<Connection Source="IA_MSS.SPEED" Destination="COMPOUND_SCALE.IN" dx1="826.67"/>
+			<Connection Source="COMPOUND_SCALE.OUT" Destination="Q_NumericValue.rPhys" dx1="1073.33"/>
+		</AdapterConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_076_AUI.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_076_AUI.SUB
@@ -13,21 +13,18 @@
 		<FB Name="IA_MSS" Type="isobus::tecu::IA_MSS" x="-1200" y="900">
 			<Parameter Name="QI" Value="TRUE"/>
 		</FB>
-		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="1100" y="1200">
+		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::AUI_FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="1100" y="800">
 			<Parameter Name="SCALE_HIGH" Value="REAL#0.256"/>
 			<Parameter Name="SCALE_LOW" Value="REAL#0.001"/>
 			<Parameter Name="OFFSET" Value="DINT#0"/>
 		</FB>
-		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5500" y="900">
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYSA" x="5500" y="800">
 			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
 		</FB>
 		<Comment Comment="TODO: &#10;NumberVariable_Machine_selected_speed&#10;im Object Pool anlegen, und hier umändern.&#10;&#10;solange verwenden wir hier NumberVariable_Wheel_based_machine_speed ersatzweise" x="3600" y="2000" width="3100" height="700"/>
-		<EventConnections>
-			<Connection Source="IA_MSS.INITO" Destination="Q_NumericValue.INIT"/>
-		</EventConnections>
 		<AdapterConnections>
 			<Connection Source="IA_MSS.SPEED" Destination="COMPOUND_SCALE.IN" dx1="826.67"/>
-			<Connection Source="COMPOUND_SCALE.OUT" Destination="Q_NumericValue.rPhys" dx1="1073.33"/>
+			<Connection Source="COMPOUND_SCALE.OUT" Destination="Q_NumericValue.rPhys"/>
 		</AdapterConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
@@ -3,6 +3,7 @@
 	<CompilerInfo packageName="Uebungen::const::UT::PWM"/>
 	<GlobalConstants>
 		<VarDeclaration Name="InputNumber_PWM_DUTY" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
+		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9001, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="InputNumber_PWM_DUTY_OUT" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9002, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_THRESHOLD" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9003, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
@@ -3,7 +3,6 @@
 	<CompilerInfo packageName="Uebungen::const::UT::PWM"/>
 	<GlobalConstants>
 		<VarDeclaration Name="InputNumber_PWM_DUTY" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
-		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9001, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="InputNumber_PWM_DUTY_OUT" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9002, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_THRESHOLD" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9003, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
@@ -14,5 +13,6 @@
 		<VarDeclaration Name="OutputNumber_075" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="OutputNumber_000" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="OutputNumber_025" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
+		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21001, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 	</GlobalConstants>
 </GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
@@ -3,15 +3,15 @@
 	<CompilerInfo packageName="Uebungen::const::UT::TECU"/>
 	<GlobalConstants>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12000, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12002, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_km" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_m" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21000, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21002, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21003, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
 	</GlobalConstants>
 </GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
@@ -3,11 +3,15 @@
 	<CompilerInfo packageName="Uebungen::const::UT::TECU"/>
 	<GlobalConstants>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12000, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12002, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_km" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_m" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
 	</GlobalConstants>
 </GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
@@ -16,17 +16,17 @@
 		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYS" x="600" y="700">
 			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
 		</FB>
-		<FB Name="FIELDBUS_UDINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UDINT_TO_SIGNAL_SCALED" x="-3500" y="800">
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_SCALED" x="-3500" y="800">
 			<Parameter Name="SCALE" Value="0.001"/>
 			<Parameter Name="OFFSET" Value="0"/>
 		</FB>
 		<EventConnections>
-			<Connection Source="I_WBSD.IND" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.REQ" dx1="473.33"/>
-			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.CNF" Destination="Q_NumericValue.REQ" dx1="1153.33"/>
+			<Connection Source="I_WBSD.IND" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED.REQ" dx1="473.33"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED.CNF" Destination="Q_NumericValue.REQ" dx1="1153.33"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="I_WBSD.WHEELBASEDMACHINESPEED" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.IN" dx1="473.33"/>
-			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.rPhys" dx1="1153.33"/>
+			<Connection Source="I_WBSD.WHEELBASEDMACHINESPEED" Destination="FIELDBUS_UINT_TO_SIGNAL_SCALED.IN" dx1="473.33"/>
+			<Connection Source="FIELDBUS_UINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.rPhys" dx1="1153.33"/>
 		</DataConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
@@ -16,7 +16,7 @@
 		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYS" x="600" y="700">
 			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
 		</FB>
-		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_SCALED" x="-3500" y="800">
+		<FB Name="FIELDBUS_UINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_SCALED" x="-3400" y="800">
 			<Parameter Name="SCALE" Value="0.001"/>
 			<Parameter Name="OFFSET" Value="0"/>
 		</FB>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_070c.SUB
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_070c" Comment="WBSD auf UT ausgeben, PHYS">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="I_WBSD" Type="isobus::tecu::I_WBSD" x="-5900" y="500">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYS" x="600" y="700">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<FB Name="FIELDBUS_UDINT_TO_SIGNAL_SCALED" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UDINT_TO_SIGNAL_SCALED" x="-3500" y="800">
+			<Parameter Name="SCALE" Value="0.001"/>
+			<Parameter Name="OFFSET" Value="0"/>
+		</FB>
+		<EventConnections>
+			<Connection Source="I_WBSD.IND" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.REQ" dx1="473.33"/>
+			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.CNF" Destination="Q_NumericValue.REQ" dx1="1153.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="I_WBSD.WHEELBASEDMACHINESPEED" Destination="FIELDBUS_UDINT_TO_SIGNAL_SCALED.IN" dx1="473.33"/>
+			<Connection Source="FIELDBUS_UDINT_TO_SIGNAL_SCALED.OUT" Destination="Q_NumericValue.rPhys" dx1="1153.33"/>
+		</DataConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_076.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_076.SUB
@@ -13,7 +13,7 @@
 		<FB Name="I_MSS" Type="isobus::tecu::I_MSS" x="-3300" y="400">
 			<Parameter Name="QI" Value="TRUE"/>
 		</FB>
-		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="-400" y="700">
+		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="-500" y="700">
 			<Parameter Name="SCALE_HIGH" Value="REAL#0.256"/>
 			<Parameter Name="SCALE_LOW" Value="REAL#0.001"/>
 			<Parameter Name="OFFSET" Value="DINT#0"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_076.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_076.SUB
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_076" Comment="MSS mit Compound Scaling auf UT ausgeben">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-06-01" Remarks="MSS Machine Selected Speed mit Compound Scaling (0.256 upper / 0.001 lower)">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="Uebungen::const::UT::TECU::DefaultPool_TECU_Numeric::NumberVariable_Wheel_based_machine_speed"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="I_MSS" Type="isobus::tecu::I_MSS" x="-3300" y="400">
+			<Parameter Name="QI" Value="TRUE"/>
+		</FB>
+		<FB Name="COMPOUND_SCALE" Type="logiBUS::signalprocessing::fieldbus::FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE" x="-400" y="700">
+			<Parameter Name="SCALE_HIGH" Value="REAL#0.256"/>
+			<Parameter Name="SCALE_LOW" Value="REAL#0.001"/>
+			<Parameter Name="OFFSET" Value="DINT#0"/>
+		</FB>
+		<FB Name="Q_NumericValue" Type="isobus::UT::Q::Q_NumericValue_PHYS" x="3900" y="600">
+			<Parameter Name="stObj" Value="NumberVariable_Wheel_based_machine_speed"/>
+		</FB>
+		<Comment Comment="TODO: &#10;NumberVariable_Machine_selected_speed&#10;im Object Pool anlegen, und hier umändern.&#10;&#10;solange verwenden wir hier NumberVariable_Wheel_based_machine_speed ersatzweise" x="1800" y="1600" width="3100" height="700"/>
+		<EventConnections>
+			<Connection Source="I_MSS.IND" Destination="COMPOUND_SCALE.REQ" dx1="66.67"/>
+			<Connection Source="COMPOUND_SCALE.CNF" Destination="Q_NumericValue.REQ" dx1="1120"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="I_MSS.SELECTEDMACHINESPEED" Destination="COMPOUND_SCALE.IN" dx1="66.67"/>
+			<Connection Source="COMPOUND_SCALE.OUT" Destination="Q_NumericValue.rPhys" dx1="1120"/>
+		</DataConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
@@ -3,6 +3,7 @@
 	<CompilerInfo packageName="Uebungen::const::UT::PWM"/>
 	<GlobalConstants>
 		<VarDeclaration Name="InputNumber_PWM_DUTY" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
+		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9001, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="InputNumber_PWM_DUTY_OUT" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9002, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_THRESHOLD" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9003, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/PWM/DefaultPool_PWM_Numeric.gcf
@@ -3,7 +3,6 @@
 	<CompilerInfo packageName="Uebungen::const::UT::PWM"/>
 	<GlobalConstants>
 		<VarDeclaration Name="InputNumber_PWM_DUTY" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
-		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9000, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9001, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="InputNumber_PWM_DUTY_OUT" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9002, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 		<VarDeclaration Name="InputNumber_THRESHOLD" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 9003, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
@@ -14,5 +13,6 @@
 		<VarDeclaration Name="OutputNumber_075" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="OutputNumber_000" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
 		<VarDeclaration Name="OutputNumber_025" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 1.0, i32Offset := 0, u8Decimals := 0)"/>
+		<VarDeclaration Name="NumberVariable_PWM_Value" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21001, r32Scale := 0.0122085215, i32Offset := 0, u8Decimals := 3)"/>
 	</GlobalConstants>
 </GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
@@ -3,15 +3,15 @@
 	<CompilerInfo packageName="Uebungen::const::UT::TECU"/>
 	<GlobalConstants>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12000, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12002, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_km" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_m" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
-		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21000, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21002, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 21003, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
 	</GlobalConstants>
 </GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/const/UT/TECU/DefaultPool_TECU_Numeric.gcf
@@ -3,11 +3,15 @@
 	<CompilerInfo packageName="Uebungen::const::UT::TECU"/>
 	<GlobalConstants>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12000, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12001, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_km_h" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12002, r32Scale := 0.0036, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Ground_based_machine_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Ground_based_machine_speed_m_s" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12003, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_km" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Wheel_based_machine_distance" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12004, r32Scale := 0.000001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Wheel_based_machine_distance_m" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12005, r32Scale := 0.001, i32Offset := 0, u8Decimals := 1)"/>
 		<VarDeclaration Name="OutputNumber_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
+		<VarDeclaration Name="NumberVariable_Rear_PTO_output_shaft_speed" Type="logiBUS::utils::conversion::phys::NumericObjectPool_S" InitialValue="(u16ObjId := 12006, r32Scale := 0.125, i32Offset := 0, u8Decimals := 1)"/>
 	</GlobalConstants>
 </GlobalConstants>


### PR DESCRIPTION
Introduces new exercises for Wheel Based Machine Speed (WBSD) and 
Machine Selected Speed (MSS) for better scaling output in TECU.

Adds new NumericObjectPool_S variables for improved PWM and TECU 
performance metrics tracking in existing configurations.

Relates to TECU2

## Summary by Sourcery

Add new TECU exercises and extend numeric pools for PWM and TECU configurations.

New Features:
- Introduce new Uebung_070c and Uebung_076 exercise definitions for TECU-related training scenarios.

Enhancements:
- Extend PWM and TECU default numeric object pools in test_AX and test_B configurations to support additional tracking variables.