### PR TITLE
Update fieldbus function blocks to use eclipse4diac signal declarations

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-30">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_BYTE_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-30">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -21,7 +21,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="DWORD" Comment="Input" InitialValue="NOT_AVAILABLE_DM"/>
+			<VarDeclaration Name="IN" Type="DWORD" Comment="Input" InitialValue="NOT_AVAILABLE_DWM"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="DWORD" Comment="Output Filtered" InitialValue="16#00000000"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_DWORD_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -27,7 +27,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="DWORD" Comment="Input" InitialValue="NOT_AVAILABLE_DM"/>
+			<VarDeclaration Name="IN" Type="DWORD" Comment="Input" InitialValue="NOT_AVAILABLE_DWM"/>
 			<VarDeclaration Name="SCALE" Type="LREAL" Comment="Scaling factor" InitialValue="LREAL#1.0"/>
 			<VarDeclaration Name="OFFSET" Type="DINT" Comment="Offset added after scaling" InitialValue="DINT#0"/>
 		</InputVars>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_LWORD_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_LWORD_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -21,7 +21,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="LWORD" Comment="Input" InitialValue="NOT_AVAILABLE_LM"/>
+			<VarDeclaration Name="IN" Type="LWORD" Comment="Input" InitialValue="NOT_AVAILABLE_LWM"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="LWORD" Comment="Output Filtered" InitialValue="LWORD#16#0000000000000000"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_LWORD_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_LWORD_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -27,7 +27,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="LWORD" Comment="Input" InitialValue="NOT_AVAILABLE_LM"/>
+			<VarDeclaration Name="IN" Type="LWORD" Comment="Input" InitialValue="NOT_AVAILABLE_LWM"/>
 			<VarDeclaration Name="SCALE" Type="LREAL" Comment="Scaling factor" InitialValue="LREAL#1.0"/>
 			<VarDeclaration Name="OFFSET" Type="DINT" Comment="Offset added after scaling" InitialValue="DINT#0"/>
 		</InputVars>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-30">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::DONT_CARE_2bit"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_2Bit"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::DONT_CARE_2bit"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_2Bit"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UDINT_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UDINT_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -21,7 +21,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="UDINT" Comment="Input" InitialValue="DWORD_TO_UDINT(NOT_AVAILABLE_DM)"/>
+			<VarDeclaration Name="IN" Type="UDINT" Comment="Input" InitialValue="DWORD_TO_UDINT(NOT_AVAILABLE_DWM)"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="UDINT" Comment="Output Filtered" InitialValue="16#00000000"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UDINT_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UDINT_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_DWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_DW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -27,7 +27,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="UDINT" Comment="Input" InitialValue="DWORD_TO_UDINT(NOT_AVAILABLE_DM)"/>
+			<VarDeclaration Name="IN" Type="UDINT" Comment="Input" InitialValue="DWORD_TO_UDINT(NOT_AVAILABLE_DWM)"/>
 			<VarDeclaration Name="SCALE" Type="LREAL" Comment="Scaling factor" InitialValue="LREAL#1.0"/>
 			<VarDeclaration Name="OFFSET" Type="DINT" Comment="Offset added after scaling" InitialValue="DINT#0"/>
 		</InputVars>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-30">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL_COMPOUND_SCALE.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_UINT_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_ULINT_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_ULINT_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -21,7 +21,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="ULINT" Comment="Input" InitialValue="LWORD_TO_ULINT(NOT_AVAILABLE_LM)"/>
+			<VarDeclaration Name="IN" Type="ULINT" Comment="Input" InitialValue="LWORD_TO_ULINT(NOT_AVAILABLE_LWM)"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="ULINT" Comment="Output Filtered" InitialValue="16#0000000000000000"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_ULINT_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_ULINT_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_LWM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_LW"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -27,7 +27,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="ULINT" Comment="Input" InitialValue="LWORD_TO_ULINT(NOT_AVAILABLE_LM)"/>
+			<VarDeclaration Name="IN" Type="ULINT" Comment="Input" InitialValue="LWORD_TO_ULINT(NOT_AVAILABLE_LWM)"/>
 			<VarDeclaration Name="SCALE" Type="LREAL" Comment="Scaling factor" InitialValue="LREAL#1.0"/>
 			<VarDeclaration Name="OFFSET" Type="DINT" Comment="Offset added after scaling" InitialValue="DINT#0"/>
 		</InputVars>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_USINT_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_USINT_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_USINT_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_USINT_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_B"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_B"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-30">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL_COMPOUND_SCALE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL_COMPOUND_SCALE.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL_SCALED.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_WORD_TO_SIGNAL_SCALED.fbt
@@ -5,8 +5,8 @@
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-05-31">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
-		<Import declaration="signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_WM"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::VALID_SIGNAL_W"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>


### PR DESCRIPTION
This change alters the import paths for signal declarations across multiple fieldbus function blocks to leverage the eclipse4diac library. This ensures compatibility and consistency with the updated library standards.

## Summary by Sourcery

Enhancements:
- Update signal declaration references in all FIELDBUS_*_TO_SIGNAL function blocks to use the eclipse4diac library for consistency and compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated internal signal processing constants across fieldbus components for improved consistency and stability.

* **Chores**
  * Standardized references to signal processing definitions for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->