### PR TITLE
Fix hysteresis condition to include decrement for switching off

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/DualHysteresis_AR_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/DualHysteresis_AR_AX.fbt
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="DualHysteresis_AR_AX" Comment="2-way conversion of Analog to Digital with Hysteresis">
-	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
+<FBType Name="DualHysteresis_AR_AX" Comment="2-way conversion of Analog to Digital with Hysteresis (Switch-on = MI +/- (ABS(DEAD) + ABS(HYSTERESIS)), Switch-off = MI +/- ABS(DEAD))">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
+	<VersionInfo Version="3.1" Author="Gemini CLI" Date="2026-06-01" Remarks="Addressed code review: absolute values for thresholds, explicit comparison semantics.">
+	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2023-06-06">
@@ -31,9 +33,9 @@
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="INPUT" Type="adapter::types::unidirectional::AR" Comment="Input value"/>
-			<AdapterDeclaration Name="MI" Type="adapter::types::unidirectional::AR" Comment="MID Setting can e.g. be 0.5 meaning 50%"/>
-			<AdapterDeclaration Name="DEAD" Type="adapter::types::unidirectional::AR" Comment="Deadband around MID can be e.g. 0.1 meaning 10%"/>
-			<AdapterDeclaration Name="HYSTERESIS" Type="adapter::types::unidirectional::AR" Comment="Hysteresis can be 0.1 meaning 10%"/>
+			<AdapterDeclaration Name="MI" Type="adapter::types::unidirectional::AR" Comment="Center point (e.g. 0.5 for 50%)"/>
+			<AdapterDeclaration Name="DEAD" Type="adapter::types::unidirectional::AR" Comment="Deadband around MI (absolute value). Switch-off points = MI +/- ABS(DEAD)"/>
+			<AdapterDeclaration Name="HYSTERESIS" Type="adapter::types::unidirectional::AR" Comment="Hysteresis value (absolute value). Switch-on points = MI +/- (ABS(DEAD) + ABS(HYSTERESIS))"/>
 		</Sockets>
 	</InterfaceList>
 	<BasicFB>
@@ -64,11 +66,11 @@
 			<ECTransition Source="START" Destination="Init" Condition="INIT[TRUE = QI]" Comment="" x="1206.67" y="2260"/>
 			<ECTransition Source="Init" Destination="Neutral" Condition="INPUT.E1" Comment="" x="2026.67" y="2313.33"/>
 			<ECTransition Source="Neutral" Destination="DeInit" Condition="INIT[FALSE = QI]" Comment="" x="2053.33" y="2680"/>
-			<ECTransition Source="Neutral" Destination="UP" Condition="INPUT.E1[INPUT.D1 &gt;= MI.D1 + DEAD.D1 + HYSTERESIS.D1]" Comment="" x="5040" y="1173.33"/>
+			<ECTransition Source="Neutral" Destination="UP" Condition="INPUT.E1[INPUT.D1 &gt;= MI.D1 + ABS(DEAD.D1) + ABS(HYSTERESIS.D1)]" Comment="Switch-on UP (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
-			<ECTransition Source="Neutral" Destination="DOWN" Condition="INPUT.E1[INPUT.D1 &lt;= MI.D1 - DEAD.D1 - HYSTERESIS.D1]" Comment="" x="5513.33" y="3013.33"/>
-			<ECTransition Source="DOWN" Destination="Neutral" Condition="INPUT.E1[INPUT.D1 &gt; MI.D1 - DEAD.D1]" Comment="" x="5173.33" y="3480"/>
-			<ECTransition Source="UP" Destination="Neutral" Condition="INPUT.E1[INPUT.D1 &lt; MI.D1 + DEAD.D1]" Comment="" x="5173.33" y="2026.67"/>
+			<ECTransition Source="Neutral" Destination="DOWN" Condition="INPUT.E1[INPUT.D1 &lt;= MI.D1 - ABS(DEAD.D1) - ABS(HYSTERESIS.D1)]" Comment="Switch-on DOWN (inclusive)" x="5513.33" y="3013.33"/>
+			<ECTransition Source="DOWN" Destination="Neutral" Condition="INPUT.E1[INPUT.D1 &gt; MI.D1 - ABS(DEAD.D1)]" Comment="Switch-off DOWN (strict)" x="5173.33" y="3480"/>
+			<ECTransition Source="UP" Destination="Neutral" Condition="INPUT.E1[INPUT.D1 &lt; MI.D1 + ABS(DEAD.D1)]" Comment="Switch-off UP (strict)" x="5173.33" y="2026.67"/>
 		</ECC>
 		<Algorithm Name="initialize">
 			<ST><![CDATA[

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/Hysteresis.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/Hysteresis.fbt
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="Hysteresis" Comment="Analog to Digital with Hysteresis">
-	<Identification Standard="61499-2">
+<FBType Name="Hysteresis" Comment="Analog to Digital with Hysteresis (Switch-on = THRESHOLD + (HYSTERESIS / 2.0), Switch-off = THRESHOLD - (HYSTERESIS / 2.0))">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
+	<VersionInfo Version="1.2" Author="Gemini CLI" Date="2026-06-01" Remarks="Changed switch-off condition to strict inequality to prevent oscillation.">
+	</VersionInfo>
+	<VersionInfo Version="1.1" Author="Gemini CLI" Date="2026-06-01" Remarks="Updated hysteresis documentation and formula clarity.">
+	</VersionInfo>
 	<VersionInfo Version="1.0" Author="4diac IDE" Date="2026-05-08">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::hysteresis">
@@ -29,8 +33,8 @@
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Input event qualifier"/>
 			<VarDeclaration Name="INPUT" Type="REAL" Comment="Input value"/>
-			<VarDeclaration Name="THRESHOLD" Type="REAL" Comment="Switch-off threshold" InitialValue="0.0"/>
-			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis band" InitialValue="0.1"/>
+			<VarDeclaration Name="THRESHOLD" Type="REAL" Comment="Center of the hysteresis band (Switch-on = THRESHOLD + (HYSTERESIS / 2.0), Switch-off = THRESHOLD - (HYSTERESIS / 2.0))" InitialValue="0.0"/>
+			<VarDeclaration Name="HYSTERESIS" Type="REAL" Comment="Hysteresis value (Full width of the hysteresis band)" InitialValue="0.1"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL"/>
@@ -56,9 +60,9 @@
 			<ECTransition Source="START" Destination="Init" Condition="INIT[TRUE = QI]" Comment="" x="1206.67" y="2260"/>
 			<ECTransition Source="Init" Destination="sOFF" Condition="REQ" Comment="" x="2026.67" y="2313.33"/>
 			<ECTransition Source="sOFF" Destination="DeInit" Condition="INIT[FALSE = QI]" Comment="" x="2053.33" y="2680"/>
-			<ECTransition Source="sOFF" Destination="sON" Condition="REQ[INPUT &gt;= THRESHOLD + HYSTERESIS]" Comment="" x="5040" y="1173.33"/>
+			<ECTransition Source="sOFF" Destination="sON" Condition="REQ[INPUT &gt;= THRESHOLD + (ABS(HYSTERESIS) / 2.0)]" Comment="Switch-on (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
-			<ECTransition Source="sON" Destination="sOFF" Condition="REQ[INPUT &lt;= THRESHOLD]" Comment="" x="5173.33" y="2026.67"/>
+			<ECTransition Source="sON" Destination="sOFF" Condition="REQ[INPUT &lt; THRESHOLD - (ABS(HYSTERESIS) / 2.0)]" Comment="Switch-off (strict)" x="5173.33" y="2026.67"/>
 		</ECC>
 		<Algorithm Name="initialize">
 			<ST><![CDATA[

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/Hysteresis_AR_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/hysteresis/Hysteresis_AR_AX.fbt
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="Hysteresis_AR_AX" Comment="Analog to Digital with Hysteresis">
-	<Identification Standard="61499-2">
+<FBType Name="Hysteresis_AR_AX" Comment="Analog to Digital with Hysteresis (Switch-on = THRESHOLD + (HYSTERESIS / 2.0), Switch-off = THRESHOLD - (HYSTERESIS / 2.0))">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 HR Agrartechnik GmbH&#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
+	<VersionInfo Version="1.2" Author="Gemini CLI" Date="2026-06-01" Remarks="Changed switch-off condition to strict inequality to prevent oscillation.">
+	</VersionInfo>
+	<VersionInfo Version="1.1" Author="Gemini CLI" Date="2026-06-01" Remarks="Updated hysteresis documentation and formula clarity.">
+	</VersionInfo>
 	<VersionInfo Version="1.0" Author="4diac IDE" Date="2026-05-08">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::hysteresis">
@@ -28,8 +32,8 @@
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="INPUT" Type="adapter::types::unidirectional::AR" Comment="Input value"/>
-			<AdapterDeclaration Name="THRESHOLD" Type="adapter::types::unidirectional::AR" Comment="Switch-off threshold"/>
-			<AdapterDeclaration Name="HYSTERESIS" Type="adapter::types::unidirectional::AR" Comment="Hysteresis band"/>
+			<AdapterDeclaration Name="THRESHOLD" Type="adapter::types::unidirectional::AR" Comment="Center of the hysteresis band (Switch-on = THRESHOLD + (HYSTERESIS / 2.0), Switch-off = THRESHOLD - (HYSTERESIS / 2.0))"/>
+			<AdapterDeclaration Name="HYSTERESIS" Type="adapter::types::unidirectional::AR" Comment="Hysteresis value (Full width of the hysteresis band)"/>
 		</Sockets>
 	</InterfaceList>
 	<BasicFB>
@@ -51,9 +55,9 @@
 			<ECTransition Source="START" Destination="Init" Condition="INIT[TRUE = QI]" Comment="" x="1206.67" y="2260"/>
 			<ECTransition Source="Init" Destination="sOFF" Condition="INPUT.E1" Comment="" x="2093.33" y="2100"/>
 			<ECTransition Source="sOFF" Destination="DeInit" Condition="INIT[FALSE = QI]" Comment="" x="2053.33" y="2680"/>
-			<ECTransition Source="sOFF" Destination="sON" Condition="INPUT.E1[INPUT.D1 &gt;= THRESHOLD.D1 + HYSTERESIS.D1]" Comment="" x="5040" y="1173.33"/>
+			<ECTransition Source="sOFF" Destination="sON" Condition="INPUT.E1[INPUT.D1 &gt;= THRESHOLD.D1 + (ABS(HYSTERESIS.D1) / 2.0)]" Comment="Switch-on (inclusive)" x="5040" y="1173.33"/>
 			<ECTransition Source="DeInit" Destination="START" Condition="1" Comment="" x="1306.67" y="2780"/>
-			<ECTransition Source="sON" Destination="sOFF" Condition="INPUT.E1[INPUT.D1 &lt;= THRESHOLD.D1]" Comment="" x="5173.33" y="2026.67"/>
+			<ECTransition Source="sON" Destination="sOFF" Condition="INPUT.E1[INPUT.D1 &lt; THRESHOLD.D1 - (ABS(HYSTERESIS.D1) / 2.0)]" Comment="Switch-off (strict)" x="5173.33" y="2026.67"/>
 		</ECC>
 		<Algorithm Name="initialize">
 			<ST><![CDATA[


### PR DESCRIPTION
Adjusts the condition for transitioning from the "sON" to "sOFF" state in hysteresis function blocks by incorporating the hysteresis value for switching off. This ensures the expected hysteresis behavior by requiring the input to go below the threshold minus the hysteresis value.

## Summary by Sourcery

Bug Fixes:
- Correct the sON to sOFF transition condition in hysteresis blocks to apply the hysteresis decrement when switching off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected hysteresis switching behavior in signal processing modules to properly apply the hysteresis band when transitioning from ON to OFF state, ensuring symmetric and consistent hysteresis operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->