### PR TITLE
Correct case in FIELDBUS_SIGNAL import and initial value

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/fieldbus/FIELDBUS_QUARTER_TO_SIGNAL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::signalprocessing::fieldbus">
 		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::DONT_CARE_2bit"/>
-		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_2Bit"/>
+		<Import declaration="eclipse4diac::signalprocessing::FIELDBUS_SIGNAL::NOT_AVAILABLE_2bit"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -21,7 +21,7 @@
 			</Event>
 		</EventOutputs>
 		<InputVars>
-			<VarDeclaration Name="IN" Type="BYTE" Comment="Input" InitialValue="NOT_AVAILABLE_2Bit"/>
+			<VarDeclaration Name="IN" Type="BYTE" Comment="Input" InitialValue="NOT_AVAILABLE_2bit"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="OUT" Type="BYTE" Comment="Output Filtered" InitialValue="16#00"/>


### PR DESCRIPTION
Standardizes the capitalization of the `FIELDBUS_SIGNAL::NOT_AVAILABLE_2bit` import and the initial value of the input variable to ensure consistency and avoid potential reference errors.

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent casing and initialization of the FIELDBUS_SIGNAL::NOT_AVAILABLE_2bit constant to prevent reference and default-value issues.