### PR TITLE
Improve CALIBRATE documentation and add E_CALIBRATE_SQ with ECC-enforced calibration sequence

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/CALIBRATE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/CALIBRATE.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CALIBRATE" Comment="Calibrate allows for offset and scale calibration of an analog input.">
-	<Identification Standard="61499-1" Description="&#9;version 1.3&#9;11. mar. 2009&#10;&#9;programmer &#9;hugo&#10;&#9;tested BY&#9;&#9;hans&#10;&#10;Calibrate allows for offset and scale calibration of an analog input.&#10;offset is calibrated to a stored reference Y_offset while CO is true.&#10;after the offset is calibrated, scale can be calibrated to a reference value Y_scale while CS is true.">
+<FBType Name="CALIBRATE" Comment="Two-point calibration (offset &amp; scale) of an analog input with BOOL-triggered calibration.">
+	<Identification Standard="61499-1" Description="&#9;version 1.3&#9;11. mar. 2009&#10;&#9;programmer &#9;hugo&#10;&#9;tested BY&#9;&#9;hans&#10;&#10;">
 	</Identification>
-	<VersionInfo Version="1.0" Author="franz" Date="2026-05-06">
+	<VersionInfo Version="2.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="OSCAT::Basic::POUs::Engineering::measurements">
 	</CompilerInfo>
@@ -46,20 +46,65 @@
 		</ECState>
 		<Algorithm Name="REQ">
 			<ST><![CDATA[
-(* check for calibration *)
+(* offset calibration: store offset so Y = Y_Offset at current X *)
 IF CO THEN
 	OFFSET := Y_Offset - X;
 ELSIF CS THEN
-	SCALE := Y_Scale / (X + OFFSET);
+	(* scale calibration: store scale so Y = Y_Scale at current X (requires OFFSET from CO!) *)
+	IF (X + OFFSET) <> 0.0 THEN
+		SCALE := Y_Scale / (X + OFFSET);
+	END_IF;
 END_IF;
-(* calculate output *)
+(* calculate calibrated output *)
 Y := (X + OFFSET) * SCALE;
-
-(* revision history hm 22.2.2007 rev 1.2 changed VAR RETAIN PERSISTENT to VAR RETAIN for better
- * compatibility wago lon contollers do not support persisitent
- * *
- * hm	11. mar. 2009	rev 1.3 changed real constants to use dot syntax *)
 ]]></ST>
 		</Algorithm>
 	</SimpleFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+
+<pre>
+Y = (X + OFFSET) * SCALE</pre>
+
+<h2>Calibration (Two-Point)</h2>
+
+<ol>
+	<li><strong>Offset (CO):</strong> Apply low reference, set Y_Offset to desired output, set CO=TRUE<br />
+	OFFSET := Y_Offset - X &rarr; shifts X so that Y = Y_Offset at this point</li>
+	<li><strong>Scale (CS):</strong> Apply high reference, set Y_Scale to desired output, set CS=TRUE<br />
+	SCALE := Y_Scale / (X + OFFSET) &rarr; scales so that Y = Y_Scale at this point</li>
+</ol>
+
+<p><strong>Note:</strong> Both Y_Offset and Y_Scale are target values on the <strong>output side</strong>.</p>
+
+<p><strong>⚠ IMPORTANT:</strong> CO must be executed <strong>before</strong> CS, because CS uses OFFSET from CO.<br />
+In a SimpleFB this order cannot be enforced by the FB itself.<br />
+See E_CALIBRATE_SQ for an event-driven variant with ECC-enforced sequencing.</p>
+
+<h2>Example</h2>
+
+<p><strong>Scenario:</strong> 4&ndash;20 mA pressure sensor via logiBUS (0&ndash;10 V, normalized to 0.0..1.0).<br />
+Desired output range: 0.0..500.0</p>
+
+<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse">
+	<tbody>
+		<tr>
+			<th>Step</th>
+			<th>Action</th>
+			<th>Result</th>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>Apply 4 mA (X=0.0), set Y_Offset=0.0, CO=TRUE</td>
+			<td>OFFSET = 0</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>Apply 20 mA (X=1.0), set Y_Scale=500.0, CS=TRUE</td>
+			<td>SCALE = 500</td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>Output:</strong> Y = (X + 0) * 500 = X * 500 = 0..500 ✓</p>
+]]></Attribute>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/CALIBRATE_3P.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/CALIBRATE_3P.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="CALIBRATE_3P" Comment="3-point calibration for joysticks (Min, Mid, Max)">
-	<Identification Standard="61499-1" Description="Calibrate_3P allows for 3-point calibration of an analog input, ideal for joysticks with center drift.">
+<FBType Name="CALIBRATE_3P" Comment="BOOL-triggered 3-point calibration for joysticks (Min, Mid, Max)">
+	<Identification Standard="61499-1">
 	</Identification>
-	<VersionInfo Version="1.0" Author="Gemini CLI" Date="2026-05-10">
+	<VersionInfo Version="1.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="OSCAT::Basic::POUs::Engineering::measurements">
 	</CompilerInfo>
@@ -53,7 +53,7 @@
 		</ECState>
 		<Algorithm Name="REQ">
 			<ST><![CDATA[
-(* check for calibration *)
+(* calibration: store current raw input for the active point *)
 IF C_MIN THEN
 	X_MIN := X;
 ELSIF C_MID THEN
@@ -62,7 +62,7 @@ ELSIF C_MAX THEN
 	X_MAX := X;
 END_IF;
 
-(* calculate output *)
+(* piecewise linear interpolation between stored calibration points *)
 IF X < X_MID THEN
 	IF X_MID > X_MIN THEN
 		Y := MIN_REF + (X - X_MIN) * (MID_REF - MIN_REF) / (X_MID - X_MIN);
@@ -77,7 +77,7 @@ ELSE
 	END_IF;
 END_IF;
 
-(* clipping *)
+(* clip output to reference range *)
 IF Y < MIN_REF THEN
 	Y := MIN_REF;
 ELSIF Y > MAX_REF THEN
@@ -86,4 +86,61 @@ END_IF;
 ]]></ST>
 		</Algorithm>
 	</SimpleFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+
+<pre>
+Y = piecewise linear interpolation between stored calibration points</pre>
+
+<h2>Calibration (3-Point)</h2>
+
+<ol>
+	<li><strong>Min (C_MIN=TRUE):</strong> Move joystick to minimum position, set C_MIN=TRUE<br />
+	X_MIN := X &rarr; stores current raw value as Min point</li>
+	<li><strong>Mid (C_MID=TRUE):</strong> Move joystick to center, set C_MID=TRUE<br />
+	X_MID := X &rarr; stores current raw value as Mid point (center)</li>
+	<li><strong>Max (C_MAX=TRUE):</strong> Move joystick to maximum position, set C_MAX=TRUE<br />
+	X_MAX := X &rarr; stores current raw value as Max point</li>
+</ol>
+
+<p><strong>Note:</strong> The calibration points can be calibrated in <strong>any order</strong> and can be repeated individually. Only one point per REQ event (ELSIF chain).</p>
+
+<h2>Output Calculation</h2>
+
+<ul>
+	<li>If X &lt; X_MID: linear interpolation between (X_MIN, MIN_REF) and (X_MID, MID_REF)</li>
+	<li>If X &gt;= X_MID: linear interpolation between (X_MID, MID_REF) and (X_MAX, MAX_REF)</li>
+	<li>Output is clipped to MIN_REF..MAX_REF</li>
+</ul>
+
+<h2>Example</h2>
+
+<p><strong>Scenario:</strong> Joystick with center drift. Raw range 0..1000, desired output -100..0..100.</p>
+
+<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse">
+	<tbody>
+		<tr>
+			<th>Step</th>
+			<th>Action</th>
+			<th>Result</th>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>Move joystick to <strong>min</strong>, set C_MIN=TRUE</td>
+			<td>X_MIN = 50 (drifted from ideal 0)</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>Move joystick to <strong>center</strong>, set C_MID=TRUE</td>
+			<td>X_MID = 520 (drifted from ideal 500)</td>
+		</tr>
+		<tr>
+			<td>3</td>
+			<td>Move joystick to <strong>max</strong>, set C_MAX=TRUE</td>
+			<td>X_MAX = 980 (drifted from ideal 1000)</td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>Output:</strong> Interpolated between MIN_REF=-100, MID_REF=0, MAX_REF=100 with clipping.</p>
+]]></Attribute>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_3P.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_3P.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="E_CALIBRATE_3P" Comment="Event-driven 3-point calibration for joysticks (Min, Mid, Max)">
-	<Identification Standard="61499-1" Description="E_CALIBRATE_3P allows for 3-point calibration of an analog input via event triggers. Ideal for joysticks with center drift.">
+	<Identification Standard="61499-1">
 	</Identification>
-	<VersionInfo Version="1.0" Author="Gemini CLI" Date="2026-05-10">
+	<VersionInfo Version="1.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="OSCAT::Basic::POUs::Engineering::measurements">
 	</CompilerInfo>
@@ -108,18 +108,88 @@ END_IF;
 		</Algorithm>
 		<Algorithm Name="C_MIN">
 			<ST><![CDATA[
+(* store current raw input as Min calibration point *)
 X_MIN := X;
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="C_MID">
 			<ST><![CDATA[
+(* store current raw input as Mid calibration point (center) *)
 X_MID := X;
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="C_MAX">
 			<ST><![CDATA[
+(* store current raw input as Max calibration point *)
 X_MAX := X;
 ]]></ST>
 		</Algorithm>
 	</BasicFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+
+<pre>
+Y = piecewise linear interpolation between stored calibration points</pre>
+
+<h2>Calibration (3-Point)</h2>
+
+<ol>
+	<li><strong>Min (EI_MIN):</strong> Move joystick to minimum position, fire EI_MIN<br />
+	X_MIN := X &rarr; stores current raw value as Min point</li>
+	<li><strong>Mid (EI_MID):</strong> Move joystick to center, fire EI_MID<br />
+	X_MID := X &rarr; stores current raw value as Mid point (center)</li>
+	<li><strong>Max (EI_MAX):</strong> Move joystick to maximum position, fire EI_MAX<br />
+	X_MAX := X &rarr; stores current raw value as Max point</li>
+</ol>
+
+<p><strong>Note:</strong> The calibration points can be calibrated in <strong>any order</strong> and can be repeated individually.</p>
+
+<h2>Output Calculation</h2>
+
+<ul>
+	<li>If X &lt; X_MID: linear interpolation between (X_MIN, MIN_REF) and (X_MID, MID_REF)</li>
+	<li>If X &gt;= X_MID: linear interpolation between (X_MID, MID_REF) and (X_MAX, MAX_REF)</li>
+	<li>Output is clipped to MIN_REF..MAX_REF</li>
+</ul>
+
+<h2>ECC State Machine</h2>
+
+<pre>
+START --REQ--&gt; REQ --1--&gt; START       (normal operation)
+START -EI_MIN-&gt; C_MIN --1--&gt; START    (calibrate minimum)
+START -EI_MID-&gt; C_MID --1--&gt; START    (calibrate center)
+START -EI_MAX-&gt; C_MAX --1--&gt; START    (calibrate maximum)</pre>
+
+<p>All calibration events are independently accessible from the START state &ndash; no enforced order.</p>
+
+<h2>Example</h2>
+
+<p><strong>Scenario:</strong> Joystick with center drift. Raw range 0..1000, desired output -100..0..100.</p>
+
+<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse">
+	<tbody>
+		<tr>
+			<th>Step</th>
+			<th>Action</th>
+			<th>Result</th>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>Move joystick to <strong>min</strong>, fire EI_MIN</td>
+			<td>X_MIN = 50 (drifted from ideal 0)</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>Move joystick to <strong>center</strong>, fire EI_MID</td>
+			<td>X_MID = 520 (drifted from ideal 500)</td>
+		</tr>
+		<tr>
+			<td>3</td>
+			<td>Move joystick to <strong>max</strong>, fire EI_MAX</td>
+			<td>X_MAX = 980 (drifted from ideal 1000)</td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>Output:</strong> Interpolated between MIN_REF=-100, MID_REF=0, MAX_REF=100 with clipping.</p>
+]]></Attribute>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_SQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_SQ.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="E_CALIBRATE" Comment="Event-driven two-point calibration (offset &amp; scale) of an analog input.">
+<FBType Name="E_CALIBRATE_SQ" Comment="Sequential two-point calibration (offset then scale) with ECC-enforced order.">
 	<Identification Standard="61499-1">
 	</Identification>
-	<VersionInfo Version="2.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
+	<VersionInfo Version="1.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="OSCAT::Basic::POUs::Engineering::measurements">
 	</CompilerInfo>
@@ -15,11 +15,12 @@
 				<With Var="OFFSET"/>
 				<With Var="SCALE"/>
 			</Event>
-			<Event Name="EICO" Type="Event" Comment="Calibrate Offset (speichert OFFSET := Y_Offset - X)">
+			<Event Name="EICO" Type="Event" Comment="Calibrate Offset (speichert OFFSET := Y_Offset / SCALE - X)">
 				<With Var="X"/>
 				<With Var="Y_Offset"/>
+				<With Var="SCALE"/>
 			</Event>
-			<Event Name="EICS" Type="Event" Comment="Calibrate Scale (speichert SCALE := Y_Scale / (X + OFFSET))">
+			<Event Name="EICS" Type="Event" Comment="Calibrate Scale (speichert SCALE und korrigiert OFFSET basierend auf beiden Punkten)">
 				<With Var="X"/>
 				<With Var="Y_Scale"/>
 				<With Var="OFFSET"/>
@@ -34,6 +35,7 @@
 			</Event>
 			<Event Name="EOCS" Type="Event" Comment="Scale Calibrated">
 				<With Var="SCALE"/>
+				<With Var="OFFSET"/>
 			</Event>
 		</EventOutputs>
 		<InputVars>
@@ -48,23 +50,38 @@
 			<VarDeclaration Name="OFFSET" Type="REAL" Comment="Stored offset value" InitialValue="0.0"/>
 			<VarDeclaration Name="SCALE" Type="REAL" Comment="Stored scale value" InitialValue="1.0"/>
 		</InOutVars>
+		<InternalVars>
+			<VarDeclaration Name="X_LOW_INT" Type="REAL" Comment="Stored raw value at CO"/>
+			<VarDeclaration Name="Y_LOW_INT" Type="REAL" Comment="Stored target value at CO"/>
+		</InternalVars>
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="REQ" x="0" y="0">
+			<ECState Name="START" x="-240" y="-160">
+			</ECState>
+			<ECState Name="REQ" x="720" y="1360">
 				<ECAction Algorithm="REQ" Output="CNF"/>
 			</ECState>
-			<ECState Name="CO" x="1600" y="0">
+			<ECState Name="CO" x="2000" y="480">
 				<ECAction Algorithm="CO" Output="EOCO"/>
 			</ECState>
-			<ECState Name="CS" x="1600" y="-400">
+			<ECState Name="WAIT_CS" x="2320" y="0">
+			</ECState>
+			<ECState Name="REQ_WAIT" x="1700" y="800">
+				<ECAction Algorithm="REQ" Output="CNF"/>
+			</ECState>
+			<ECState Name="CS" x="2400" y="-400">
 				<ECAction Algorithm="CS" Output="EOCS"/>
 			</ECState>
-			<ECTransition Source="REQ" Destination="CS" Condition="EICS" Comment="" x="760" y="-200"/>
-			<ECTransition Source="REQ" Destination="CO" Condition="EICO" Comment="" x="780" y="453.33"/>
-			<ECTransition Source="CS" Destination="REQ" Condition="1" Comment="" x="706.67" y="-460"/>
-			<ECTransition Source="CO" Destination="REQ" Condition="1" Comment="" x="780" y="653.33"/>
-			<ECTransition Source="REQ" Destination="REQ" Condition="REQ" Comment="" x="-186.67" y="633.33"/>
+			<ECTransition Source="START" Destination="REQ" Condition="REQ" Comment="" x="473.33" y="533.33"/>
+			<ECTransition Source="REQ" Destination="START" Condition="1" Comment="" x="306.67" y="700"/>
+			<ECTransition Source="START" Destination="CO" Condition="EICO" Comment="" x="800" y="400"/>
+			<ECTransition Source="CO" Destination="WAIT_CS" Condition="1" Comment="" x="2060" y="213.33"/>
+			<ECTransition Source="WAIT_CS" Destination="REQ_WAIT" Condition="REQ" Comment="" x="1733.33" y="166.67"/>
+			<ECTransition Source="REQ_WAIT" Destination="WAIT_CS" Condition="1" Comment="" x="1900" y="400"/>
+			<ECTransition Source="WAIT_CS" Destination="CS" Condition="EICS" Comment="" x="3146.67" y="-86.67"/>
+			<ECTransition Source="CS" Destination="START" Condition="1" Comment="" x="1213.33" y="-813.33"/>
+			<ECTransition Source="WAIT_CS" Destination="CO" Condition="EICO" Comment="" x="2846.67" y="380"/>
 		</ECC>
 		<Algorithm Name="REQ">
 			<ST><![CDATA[
@@ -74,16 +91,22 @@ Y := (X + OFFSET) * SCALE;
 		</Algorithm>
 		<Algorithm Name="CO">
 			<ST><![CDATA[
-(* store offset so that Y = Y_Offset at current X *)
-(* note: after CO, Y = Y_Offset * SCALE, only correct when SCALE = 1 *)
-OFFSET := Y_Offset - X;
+X_LOW_INT := X;
+Y_LOW_INT := Y_Offset;
+IF SCALE <> 0.0 THEN
+	OFFSET := Y_Offset / SCALE - X;
+ELSE
+	OFFSET := Y_Offset - X;
+END_IF;
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="CS">
 			<ST><![CDATA[
-(* store scale so that Y = Y_Scale at current X (requires OFFSET from CO!) *)
-IF (X + OFFSET) <> 0.0 THEN
-	SCALE := Y_Scale / (X + OFFSET);
+IF (X - X_LOW_INT) <> 0.0 THEN
+	SCALE := (Y_Scale - Y_LOW_INT) / (X - X_LOW_INT);
+	IF SCALE <> 0.0 THEN
+		OFFSET := Y_LOW_INT / SCALE - X_LOW_INT;
+	END_IF;
 END_IF;
 ]]></ST>
 		</Algorithm>
@@ -93,41 +116,39 @@ END_IF;
 <pre>
 Y = (X + OFFSET) * SCALE</pre>
 
-<h2>Calibration (Two-Point)</h2>
+<h2>Calibration (Two-Point, ECC-Enforced)</h2>
 
 <ol>
 	<li><strong>Offset (EICO):</strong> Apply low reference, set Y_Offset to desired output, fire EICO<br />
-	OFFSET := Y_Offset - X &rarr; shifts X so that Y = Y_Offset * SCALE at this point<br />
-	<strong>Note:</strong> Only correct when SCALE = 1. See E_CALIBRATE_SQ for a formula that works regardless of SCALE.</li>
+	OFFSET := Y_Offset / SCALE - X &rarr; after CO, Y <strong>always</strong> equals Y_Offset (independent of SCALE)</li>
 	<li><strong>Scale (EICS):</strong> Apply high reference, set Y_Scale to desired output, fire EICS<br />
-	SCALE := Y_Scale / (X + OFFSET) &rarr; scales so that Y = Y_Scale at this point</li>
+	Calculates SCALE and OFFSET decoupled using both reference points &rarr; after CS, the line passes exactly through both points</li>
 </ol>
 
 <p><strong>Note:</strong> Both Y_Offset and Y_Scale are target values on the <strong>output side</strong>.</p>
 
 <ul>
-	<li>REQ (normal operation) is always possible</li>
-	<li>CO must be executed <strong>before</strong> CS, because CS uses OFFSET</li>
-	<li>This FB does <strong>not</strong> enforce the order &ndash; both EICO and EICS are directly accessible from REQ</li>
-	<li>See E_CALIBRATE_SQ for an ECC-enforced variant</li>
+	<li>REQ (normal operation) is always possible, even between CO and CS</li>
+	<li>EICS is only reachable <strong>after</strong> offset calibration (state WAIT_CS)</li>
+	<li>EICO can be repeated at any time to re-calibrate offset</li>
 </ul>
 
 <h2>ECC State Machine</h2>
 
 <pre>
-REQ --EICO--&gt; CO  --1--&gt; REQ     (offset calibration)
-REQ --EICS--&gt; CS  --1--&gt; REQ     (scale calibration)
-REQ --REQ---&gt; REQ --1--&gt; REQ     (normal operation)</pre>
+START --REQ--&gt; REQ --1--&gt; START       (normal operation)
+START -EICO-&gt; CO  --1--&gt; WAIT_CS     (offset calibrated)
+WAIT_CS -REQ--&gt; REQ --1--&gt; WAIT_CS  (operation with offset only)
+WAIT_CS -EICO-&gt; CO  --1--&gt; WAIT_CS  (re-calibrate offset)
+WAIT_CS -EICS-&gt; CS  --1--&gt; START     (scale calibrated, done)</pre>
 
-<p><strong>No order enforcement:</strong> EICO and EICS are both directly reachable from REQ.</p>
-
-<h2>Key Difference: E_CALIBRATE vs. E_CALIBRATE_SQ</h2>
+<h2>Key Difference vs. CALIBRATE</h2>
 
 <table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse">
 	<tbody>
 		<tr>
 			<th>Feature</th>
-			<th>E_CALIBRATE</th>
+			<th>CALIBRATE</th>
 			<th>E_CALIBRATE_SQ</th>
 		</tr>
 		<tr>
@@ -144,8 +165,13 @@ REQ --REQ---&gt; REQ --1--&gt; REQ     (normal operation)</pre>
 		</tr>
 		<tr>
 			<td><strong>Order enforcement</strong></td>
-			<td>None (ECC, both accessible from REQ)</td>
+			<td>None (SimpleFB)</td>
 			<td>ECC-enforced (CO before CS)</td>
+		</tr>
+		<tr>
+			<td><strong>Trigger</strong></td>
+			<td>BOOL inputs (CO, CS)</td>
+			<td>Events (EICO, EICS)</td>
 		</tr>
 	</tbody>
 </table>
@@ -165,12 +191,12 @@ Desired output range: 0.0..500.0</p>
 		<tr>
 			<td>1</td>
 			<td>Apply 4 mA (X=0.0), set Y_Offset=0.0, fire EICO</td>
-			<td>OFFSET = 0</td>
+			<td>OFFSET = 0/1 &minus; 0 = 0</td>
 		</tr>
 		<tr>
 			<td>2</td>
 			<td>Apply 20 mA (X=1.0), set Y_Scale=500.0, fire EICS</td>
-			<td>SCALE = 500</td>
+			<td>SCALE = 500/(1+0) = 500</td>
 		</tr>
 	</tbody>
 </table>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_CALIBRATE" Comment="Calibrate allows for offset and scale calibration of an analog input (with Adapter)">
-	<Identification Standard="61499-1" Description="&#9;version 1.3&#9;11. mar. 2009&#10;&#9;programmer &#9;hugo&#10;&#9;tested BY&#9;&#9;hans&#10;&#10;Calibrate allows for offset and scale calibration of an analog input.&#10;offset is calibrated to a stored reference Y_offset while CO is true.&#10;after the offset is calibrated, scale can be calibrated to a reference value Y_scale while CS is true.">
+<FBType Name="AR_CALIBRATE" Comment="Adapter-based two-point calibration (offset &amp; scale) of an analog input">
+	<Identification Standard="61499-1">
 	</Identification>
-	<VersionInfo Version="1.0" Author="franz" Date="2026-05-06">
+	<VersionInfo Version="2.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="adapter::Engineering::measurements">
 	</CompilerInfo>
@@ -51,19 +51,39 @@
 		</ECC>
 		<Algorithm Name="REQ" Comment="REQ">
 			<ST><![CDATA[
+(* calculate calibrated output *)
 Y.D1 := (X.D1 + OFFSET.DI1) * SCALE.DI1;
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="CO" Comment="CO">
 			<ST><![CDATA[
+(* store offset so that Y = Y_Offset at current X *)
+(* note: after CO, Y = Y_Offset * SCALE, only correct when SCALE = 1 *)
 OFFSET.DO1 := Y_Offset - X.D1;
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="CS" Comment="CS">
 			<ST><![CDATA[
-SCALE.DO1 := Y_Scale / (X.D1 + OFFSET.DI1);
+(* store scale so that Y = Y_Scale at current X (requires OFFSET from CO!) *)
+IF (X.D1 + OFFSET.DI1) <> 0.0 THEN
+	SCALE.DO1 := Y_Scale / (X.D1 + OFFSET.DI1);
+END_IF;
 ]]></ST>
 		</Algorithm>
 	</BasicFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+<pre>Y = (X + OFFSET) * SCALE</pre>
+
+<h2>Calibration (Two-Point)</h2>
+<ol>
+<li><strong>Offset (CO):</strong> Apply low reference, set <code>Y_Offset</code> to desired output, trigger <code>CO</code><br/>
+<code>OFFSET := Y_Offset - X</code> &rarr; shifts <code>X</code> so that <code>Y = Y_Offset * SCALE</code> at this point<br/>
+<strong>Note:</strong> Only correct when <code>SCALE = 1</code>.</li>
+<li><strong>Scale (CS):</strong> Apply high reference, set <code>Y_Scale</code> to desired output, trigger <code>CS</code><br/>
+<code>SCALE := Y_Scale / (X + OFFSET)</code> &rarr; scales so that <code>Y = Y_Scale</code> at this point</li>
+</ol>
+<p><strong>Note:</strong> Both <code>Y_Offset</code> and <code>Y_Scale</code> are target values on the <strong>output side</strong>.</p>
+<p><strong>&#9888; Order requirement:</strong> <code>CO</code> must be executed <strong>before</strong> <code>CS</code>, because <code>CS</code> uses <code>OFFSET</code>.</p>
+]]></Attribute>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_3P.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_3P.fbt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_CALIBRATE_3P" Comment="3-point calibration for joysticks (Min, Mid, Max) with Adapters">
-	<Identification Standard="61499-1" Description="AR_CALIBRATE_3P allows for 3-point calibration of an analog input using adapters. Ideal for joysticks with center drift.">
+<FBType Name="AR_CALIBRATE_3P" Comment="Adapter-based 3-point calibration for joysticks (Min, Mid, Max)">
+	<Identification Standard="61499-1">
 	</Identification>
-	<VersionInfo Version="1.0" Author="Gemini CLI" Date="2026-05-10">
+	<VersionInfo Version="1.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
 	</VersionInfo>
 	<CompilerInfo packageName="adapter::Engineering::measurements">
 	</CompilerInfo>
@@ -34,7 +34,8 @@
 	</InterfaceList>
 	<BasicFB>
 		<ECC>
-			<ECState Name="IDLE" x="400" y="400"/>
+			<ECState Name="IDLE" x="400" y="400">
+			</ECState>
 			<ECState Name="REQ" x="1200" y="400">
 				<ECAction Algorithm="REQ" Output="Y.E1"/>
 			</ECState>
@@ -47,18 +48,18 @@
 			<ECState Name="CAL_MAX" x="1200" y="1200">
 				<ECAction Algorithm="CAL_MAX" Output="X_MAX.EO1"/>
 			</ECState>
-			<ECTransition Source="IDLE" Destination="REQ" Condition="X.E1" x="800" y="400"/>
-			<ECTransition Source="REQ" Destination="IDLE" Condition="1" x="800" y="500"/>
-			<ECTransition Source="IDLE" Destination="IDLE" Condition="SET" x="200" y="200"/>
-			<ECTransition Source="IDLE" Destination="IDLE" Condition="X_MIN.EI1" x="200" y="300"/>
-			<ECTransition Source="IDLE" Destination="IDLE" Condition="X_MID.EI1" x="200" y="400"/>
-			<ECTransition Source="IDLE" Destination="IDLE" Condition="X_MAX.EI1" x="200" y="500"/>
-			<ECTransition Source="IDLE" Destination="CAL_MIN" Condition="C_MIN.E1[C_MIN.D1]" x="800" y="200"/>
-			<ECTransition Source="CAL_MIN" Destination="IDLE" Condition="1" x="800" y="100"/>
-			<ECTransition Source="IDLE" Destination="CAL_MID" Condition="C_MID.E1[C_MID.D1]" x="800" y="600"/>
-			<ECTransition Source="CAL_MID" Destination="IDLE" Condition="1" x="800" y="700"/>
-			<ECTransition Source="IDLE" Destination="CAL_MAX" Condition="C_MAX.E1[C_MAX.D1]" x="800" y="1000"/>
-			<ECTransition Source="CAL_MAX" Destination="IDLE" Condition="1" x="800" y="1100"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="X.E1" Comment="" x="800" y="400"/>
+			<ECTransition Source="REQ" Destination="IDLE" Condition="1" Comment="" x="800" y="500"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="SET" Comment="" x="200" y="200"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="X_MIN.EI1" Comment="" x="200" y="300"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="X_MID.EI1" Comment="" x="200" y="400"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="X_MAX.EI1" Comment="" x="200" y="500"/>
+			<ECTransition Source="IDLE" Destination="CAL_MIN" Condition="C_MIN.E1[C_MIN.D1]" Comment="" x="800" y="200"/>
+			<ECTransition Source="CAL_MIN" Destination="IDLE" Condition="1" Comment="" x="800" y="100"/>
+			<ECTransition Source="IDLE" Destination="CAL_MID" Condition="C_MID.E1[C_MID.D1]" Comment="" x="800" y="600"/>
+			<ECTransition Source="CAL_MID" Destination="IDLE" Condition="1" Comment="" x="800" y="700"/>
+			<ECTransition Source="IDLE" Destination="CAL_MAX" Condition="C_MAX.E1[C_MAX.D1]" Comment="" x="800" y="1000"/>
+			<ECTransition Source="CAL_MAX" Destination="IDLE" Condition="1" Comment="" x="800" y="1100"/>
 		</ECC>
 		<Algorithm Name="REQ">
 			<ST><![CDATA[
@@ -101,5 +102,36 @@ X_MAX.DO1 := X.D1;
 ]]></ST>
 		</Algorithm>
 	</BasicFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+<pre>Y = piecewise linear interpolation between stored calibration points</pre>
+
+<h2>Calibration (3-Point)</h2>
+<ol>
+<li><strong>Min (C_MIN):</strong> Move joystick to minimum, trigger <code>C_MIN</code><br/>
+<code>X_MIN := X</code> &rarr; stores current raw value as Min point</li>
+<li><strong>Mid (C_MID):</strong> Move joystick to center, trigger <code>C_MID</code><br/>
+<code>X_MID := X</code> &rarr; stores current raw value as Mid point (center)</li>
+<li><strong>Max (C_MAX):</strong> Move joystick to maximum, trigger <code>C_MAX</code><br/>
+<code>X_MAX := X</code> &rarr; stores current raw value as Max point</li>
+</ol>
+<p><strong>Note:</strong> Calibration points can be calibrated in <strong>any order</strong> and repeated individually.</p>
+
+<h2>Output Calculation</h2>
+<ul>
+<li>If <code>X &lt; X_MID</code>: linear interpolation between <code>(X_MIN, MIN_REF)</code> and <code>(X_MID, MID_REF)</code></li>
+<li>If <code>X &gt;= X_MID</code>: linear interpolation between <code>(X_MID, MID_REF)</code> and <code>(X_MAX, MAX_REF)</code></li>
+<li>Output clipped to <code>MIN_REF..MAX_REF</code></li>
+</ul>
+
+<h2>Example</h2>
+<p><strong>Scenario:</strong> Joystick with center drift. Raw range <code>0..1000</code>, desired output <code>-100..0..100</code>.</p>
+<table border="1" cellpadding="4" style="border-collapse:collapse">
+<tr><th>Step</th><th>Action</th><th>Result</th></tr>
+<tr><td>1</td><td>Move joystick to <strong>min</strong>, trigger <code>C_MIN</code></td><td><code>X_MIN = 50</code> (drifted from ideal 0)</td></tr>
+<tr><td>2</td><td>Move joystick to <strong>center</strong>, trigger <code>C_MID</code></td><td><code>X_MID = 520</code> (drifted from ideal 500)</td></tr>
+<tr><td>3</td><td>Move joystick to <strong>max</strong>, trigger <code>C_MAX</code></td><td><code>X_MAX = 980</code> (drifted from ideal 1000)</td></tr>
+</table>
+<p><strong>Output:</strong> Interpolated between <code>MIN_REF=-100</code>, <code>MID_REF=0</code>, <code>MAX_REF=100</code> with clipping.</p>
+]]></Attribute>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_SQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_SQ.fbt
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_CALIBRATE_SQ" Comment="Adapter-based sequential two-point calibration (offset then scale) with ECC-enforced order">
+	<Identification Standard="61499-1">
+	</Identification>
+	<VersionInfo Version="1.0" Author="Meisterschulen am Ostbahnhof" Date="2026-06-01">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::Engineering::measurements">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="SET" Type="EInit" Comment="Set References">
+				<With Var="Y_Offset"/>
+				<With Var="Y_Scale"/>
+			</Event>
+		</EventInputs>
+		<InputVars>
+			<VarDeclaration Name="Y_Offset" Type="REAL" Comment="Target output Y at low calibration point (offset)"/>
+			<VarDeclaration Name="Y_Scale" Type="REAL" Comment="Target output Y at high calibration point (scale)"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="Y" Type="adapter::types::unidirectional::AR" Comment="Calibrated Output"/>
+			<AdapterDeclaration Name="OFFSET" Type="adapter::types::bidirectional::AR2" Comment="Stored offset value (initial 0.0)"/>
+			<AdapterDeclaration Name="SCALE" Type="adapter::types::bidirectional::AR2" Comment="Stored scale value (initial 1.0)"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="X" Type="adapter::types::unidirectional::AR" Comment="Raw Input"/>
+			<AdapterDeclaration Name="CO" Type="adapter::types::unidirectional::AX" Comment="Calibrate Offset"/>
+			<AdapterDeclaration Name="CS" Type="adapter::types::unidirectional::AX" Comment="Calibrate Scale"/>
+		</Sockets>
+		<InternalVars>
+			<VarDeclaration Name="X_LOW_INT" Type="REAL" Comment="Stored raw value at CO"/>
+			<VarDeclaration Name="Y_LOW_INT" Type="REAL" Comment="Stored target value at CO"/>
+		</InternalVars>
+	</InterfaceList>
+	<BasicFB>
+		<ECC>
+			<ECState Name="IDLE" x="0" y="0">
+			</ECState>
+			<ECState Name="REQ" x="800" y="0">
+				<ECAction Algorithm="REQ" Output="Y.E1"/>
+			</ECState>
+			<ECState Name="CO" x="1600" y="0">
+				<ECAction Algorithm="CO" Output="OFFSET.EO1"/>
+			</ECState>
+			<ECState Name="WAIT_CS" x="1600" y="-400">
+			</ECState>
+			<ECState Name="REQ_WAIT" x="1200" y="-800">
+				<ECAction Algorithm="REQ" Output="Y.E1"/>
+			</ECState>
+			<ECState Name="CS" x="2400" y="-400">
+				<ECAction Algorithm="CS" Output="SCALE.EO1"/>
+				<ECAction Output="OFFSET.EO1"/>
+			</ECState>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="X.E1" Comment="" x="400" y="200"/>
+			<ECTransition Source="REQ" Destination="IDLE" Condition="1" Comment="" x="400" y="600"/>
+			<ECTransition Source="IDLE" Destination="CO" Condition="CO.E1[CO.D1]" Comment="" x="800" y="400"/>
+			<ECTransition Source="CO" Destination="WAIT_CS" Condition="1" Comment="" x="1600" y="-200"/>
+			<ECTransition Source="WAIT_CS" Destination="REQ_WAIT" Condition="X.E1" Comment="" x="1200" y="-200"/>
+			<ECTransition Source="REQ_WAIT" Destination="WAIT_CS" Condition="1" Comment="" x="1400" y="-600"/>
+			<ECTransition Source="WAIT_CS" Destination="CS" Condition="CS.E1[CS.D1]" Comment="" x="2000" y="-400"/>
+			<ECTransition Source="CS" Destination="IDLE" Condition="1" Comment="" x="1200" y="-600"/>
+			<ECTransition Source="WAIT_CS" Destination="CO" Condition="CO.E1[CO.D1]" Comment="" x="1600" y="-600"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="SET" Comment="" x="-100" y="200"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="OFFSET.EI1" Comment="" x="-100" y="300"/>
+			<ECTransition Source="IDLE" Destination="REQ" Condition="SCALE.EI1" Comment="" x="-100" y="400"/>
+			<ECTransition Source="WAIT_CS" Destination="REQ_WAIT" Condition="SET" Comment="" x="1400" y="-500"/>
+			<ECTransition Source="WAIT_CS" Destination="REQ_WAIT" Condition="OFFSET.EI1" Comment="" x="1400" y="-550"/>
+			<ECTransition Source="WAIT_CS" Destination="REQ_WAIT" Condition="SCALE.EI1" Comment="" x="1400" y="-600"/>
+		</ECC>
+		<Algorithm Name="REQ" Comment="REQ">
+			<ST><![CDATA[
+(* calculate calibrated output *)
+Y.D1 := (X.D1 + OFFSET.DI1) * SCALE.DI1;
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="CO" Comment="CO">
+			<ST><![CDATA[
+X_LOW_INT := X.D1;
+Y_LOW_INT := Y_Offset;
+IF SCALE.DI1 <> 0.0 THEN
+	OFFSET.DO1 := Y_Offset / SCALE.DI1 - X.D1;
+ELSE
+	OFFSET.DO1 := Y_Offset - X.D1;
+END_IF;
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="CS" Comment="CS">
+			<ST><![CDATA[
+IF (X.D1 - X_LOW_INT) <> 0.0 THEN
+	SCALE.DO1 := (Y_Scale - Y_LOW_INT) / (X.D1 - X_LOW_INT);
+	IF SCALE.DO1 <> 0.0 THEN
+		OFFSET.DO1 := Y_LOW_INT / SCALE.DO1 - X_LOW_INT;
+	END_IF;
+END_IF;
+]]></ST>
+		</Algorithm>
+	</BasicFB>
+	<Attribute Name="Documentation" Type="CDATA"><![CDATA[<h2>Formula</h2>
+
+<pre>
+Y = (X + OFFSET) * SCALE</pre>
+
+<h2>Calibration (Two-Point, ECC-Enforced)</h2>
+
+<ol>
+	<li><strong>Offset (CO):</strong> Apply low reference, set Y_Offset to desired output, trigger CO<br />
+	OFFSET := Y_Offset / SCALE - X &rarr; after CO, Y <strong>always</strong> equals Y_Offset (independent of SCALE)</li>
+	<li><strong>Scale (CS):</strong> Apply high reference, set Y_Scale to desired output, trigger CS<br />
+	Calculates SCALE and OFFSET decoupled using both reference points &rarr; after CS, the line passes exactly through both points</li>
+</ol>
+
+<p><strong>Note:</strong> Both Y_Offset and Y_Scale are target values on the <strong>output side</strong>.</p>
+
+<ul>
+	<li>CS is only reachable <strong>after</strong> offset calibration (state WAIT_CS) &ndash; enforced by ECC</li>
+	<li>CO can be repeated at any time to re-calibrate offset</li>
+	<li>Normal calculation via X.E1 works in all states</li>
+</ul>
+
+<h2>Key Difference vs. AR_CALIBRATE</h2>
+
+<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse">
+	<tbody>
+		<tr>
+			<th>Feature</th>
+			<th>AR_CALIBRATE</th>
+			<th>AR_CALIBRATE_SQ</th>
+		</tr>
+		<tr>
+			<td><strong>CO formula</strong></td>
+			<td>OFFSET := Y_Offset - X</td>
+			<td>OFFSET := Y_Offset / SCALE - X</td>
+		</tr>
+		<tr>
+			<td><strong>Y after CO</strong></td>
+			<td>Y = Y_Offset * SCALE<br />
+			(only correct when SCALE = 1)</td>
+			<td>Y = Y_Offset<br />
+			(always correct)</td>
+		</tr>
+		<tr>
+			<td><strong>Order enforcement</strong></td>
+			<td>None (both directly accessible)</td>
+			<td>ECC-enforced (CO before CS)</td>
+		</tr>
+	</tbody>
+</table>
+]]></Attribute>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/plan_calibrate_improvements.md
+++ b/plan_calibrate_improvements.md
@@ -12,9 +12,9 @@
 
 ## Maßnahmen
 
-### 1. `CALIBRATE.fbt` – Umbenennung + Doku-Aufwertung
+### 1. `CALIBRATE.fbt` – Doku-Aufwertung
 
-- **`Y_Offset` → `Y_LOW`** (Paar mit `Y_Scale`: "Low-Referenz" / "Scale-Referenz", beide von der Ausgangsseite)
+- **`Y_Offset` beibehalten** (zur Wahrung der Abwärtskompatibilität, aber in der Dokumentation klarstellen, dass es sich um einen Sollwert auf der Ausgangsseite handelt)
 - **Dokumentation erweitern (Original-Formel bleibt unverändert):**
   - Formel: `Y = (X + OFFSET) * SCALE`
   - `CO` (Calibrate Offset): `OFFSET := Y_LOW - X` — speichert den Offset. **Achtung:** Nach CO gilt `Y = Y_LOW * SCALE`, also nur korrekt, wenn `SCALE = 1.0`. Für SCALE-unabhängiges CO siehe `E_CALIBRATE_SQ`.

--- a/plan_calibrate_improvements.md
+++ b/plan_calibrate_improvements.md
@@ -1,0 +1,88 @@
+# Plan: CALIBRATE Verbesserungen
+
+## Ausgangslage
+
+[`CALIBRATE.fbt`](Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/CALIBRATE.fbt) funktioniert, hat aber zwei Probleme:
+
+1. **Keine Reihenfolge-Erzwingung:** `CO` muss zwingend vor `CS` erfolgen, da `CS` den bereits berechneten `OFFSET` verwendet (`SCALE := Y_Scale / (X + OFFSET)`). Der SimpleFB lässt beide BOOL-Eingänge gleichzeitig oder in beliebiger Reihenfolge zu.
+2. **`Y_Offset` ist nicht intuitiv:** Der Name klingt nach "Offset-Betrag" auf der Eingangsseite, ist aber tatsächlich ein **Sollwert auf der Ausgangsseite** ("Welchen Y-Wert soll ich bei diesem X liefern?").
+   - **Tieferes Problem (nur E_CALIBRATE_SQ adressiert):** Nach `CO` gilt `Y = Y_Offset * SCALE` – also nur korrekt wenn `SCALE = 1.0`.  
+     Die alte Formel `OFFSET := Y_Offset - X` liefert `Y = (X + (Y_Offset - X)) * SCALE = Y_Offset * SCALE`.  
+     **Korrekt muss es sein:** `OFFSET := Y_Offset / SCALE - X`, damit `Y = (X + (Y_Offset/SCALE - X)) * SCALE = Y_Offset` **immer** gilt.
+
+## Maßnahmen
+
+### 1. `CALIBRATE.fbt` – Umbenennung + Doku-Aufwertung
+
+- **`Y_Offset` → `Y_LOW`** (Paar mit `Y_Scale`: "Low-Referenz" / "Scale-Referenz", beide von der Ausgangsseite)
+- **Dokumentation erweitern (Original-Formel bleibt unverändert):**
+  - Formel: `Y = (X + OFFSET) * SCALE`
+  - `CO` (Calibrate Offset): `OFFSET := Y_LOW - X` — speichert den Offset. **Achtung:** Nach CO gilt `Y = Y_LOW * SCALE`, also nur korrekt, wenn `SCALE = 1.0`. Für SCALE-unabhängiges CO siehe `E_CALIBRATE_SQ`.
+  - `CS` (Calibrate Scale): `SCALE := Y_Scale / (X + OFFSET)` — speichert die Skalierung, damit bei aktuellem X der Sollwert Y_Scale erscheint
+  - **Wichtig:** `CO` muss **vor** `CS` ausgeführt werden
+- Lizenz-Header vervollständigen
+
+### 2. `E_CALIBRATE_SQ.fbt` – Neuanlage
+
+Event-gesteuerter BasicFB mit **ECC-erzwungener Reihenfolge** CO → CS.
+
+#### Interface
+| Typ | Name | Beschreibung |
+|-----|------|-------------|
+| EI | `REQ` | Normalbetrieb: berechne Y |
+| EI | `EICO` | Offset kalibrieren (Punkt 1 setzen) |
+| EI | `EICS` | Scale kalibrieren (Punkt 2 setzen) |
+| EO | `CNF` | Bestätigung Normalbetrieb |
+| EO | `EOCO` | Punkt 1 (Offset) kalibriert |
+| EO | `EOCS` | Punkt 2 (Scale) kalibriert |
+| Input | `X` | Rohwert |
+| Input | `Y_Offset` | Soll-Y bei Punkt 1 (Low) |
+| Input | `Y_Scale` | Soll-Y bei Punkt 2 (High) |
+| Output | `Y` | Kalibrierter Ausgang |
+| InOut | `OFFSET` (0.0) | Gespeicherter Offset |
+| InOut | `SCALE` (1.0) | Gespeicherte Skalierung |
+
+#### Interne Variablen
+- `X_LOW_INT` (REAL): Speichert X-Wert von EICO
+- `Y_LOW_INT` (REAL): Speichert Y_Offset von EICO
+
+#### ECC (Zustandsautomat)
+
+```
+START ──REQ──→ REQ ──1──→ START       (Normalbetrieb, Y = (X+OFFSET)*SCALE)
+START ──EICO─→ CO  ──1──→ WAIT_CS     (Referenzpunkt 1 speichern)
+WAIT_CS ──REQ──→ REQ ──1──→ WAIT_CS  (Betrieb mit aktuellem OFFSET/SCALE)
+WAIT_CS ──EICO─→ CO  ──1──→ WAIT_CS  (Referenzpunkt 1 neu setzen)
+WAIT_CS ──EICS─→ CS  ──1──→ START     (Referenzpunkt 2 speichern + Berechnung)
+```
+
+**Enforcement:** `EICS` ist nur aus `WAIT_CS` erreichbar. Der Anwender muss zwingend zuerst `EICO` triggern.
+
+#### Algorithmen
+
+```
+Algorithm REQ:  Y := (X + OFFSET) * SCALE;
+
+Algorithm CO:   
+  X_LOW_INT := X;
+  Y_LOW_INT := Y_Offset;
+  (* Optional: Sofortige Offset-Anpassung für die Anzeige bis EICS erfolgt *)
+  IF SCALE <> 0.0 THEN OFFSET := Y_Offset / SCALE - X; ELSE OFFSET := Y_Offset - X; END_IF;
+
+Algorithm CS:   
+  (* Mathematisch entkoppelte Zwei-Punkt-Kalibrierung *)
+  IF (X - X_LOW_INT) <> 0.0 THEN
+    SCALE := (Y_Scale - Y_LOW_INT) / (X - X_LOW_INT);
+    IF SCALE <> 0.0 THEN
+      OFFSET := Y_LOW_INT / SCALE - X_LOW_INT;
+    END_IF;
+  END_IF;
+```
+
+**Kernunterschied zu CALIBRATE:** Durch Speicherung von `X_LOW_INT` und `Y_LOW_INT` kann `CS` beide Parameter (`SCALE` und `OFFSET`) so berechnen, dass die Gerade exakt durch beide Punkte (Punkt 1 von EICO und Punkt 2 von EICS) geht. Die Reihenfolge-Erzwingung stellt sicher, dass die Basisdaten vorhanden sind.
+
+## Ablauf
+
+1. `CALIBRATE.fbt` editieren: `Y_Offset` → `Y_LOW`, Doku verbessern, Lizenz-Header
+2. `E_CALIBRATE_SQ.fbt` neu anlegen im selben Ordner
+3. Beide Dateien mit `python script/check_missing_ax.py` und `python script/scan_bad_names.py` validieren

--- a/plan_calibrate_improvements.md
+++ b/plan_calibrate_improvements.md
@@ -83,6 +83,6 @@ Algorithm CS:
 
 ## Ablauf
 
-1. `CALIBRATE.fbt` editieren: `Y_Offset` → `Y_LOW`, Doku verbessern, Lizenz-Header
+1. `CALIBRATE.fbt` editieren: Doku verbessern, Lizenz-Header
 2. `E_CALIBRATE_SQ.fbt` neu anlegen im selben Ordner
 3. Beide Dateien mit `python script/check_missing_ax.py` und `python script/scan_bad_names.py` validieren


### PR DESCRIPTION
## Summary by Sourcery

Improve calibration function blocks documentation and introduce an ECC-enforced calibration sequence variant.

New Features:
- Add E_CALIBRATE_SQ function block implementing an ECC-enforced two-point calibration sequence.
- Add AR_CALIBRATE_SQ adapter block wiring for the new E_CALIBRATE_SQ sequence variant.

Enhancements:
- Refine existing CALIBRATE and E_CALIBRATE 2-/3-point function blocks and their adapter variants to improve naming and documentation consistency.

Documentation:
- Add a planning document describing current CALIBRATE issues and the design of the new ECC-enforced calibration sequence.
- Clarify and extend CALIBRATE-related documentation, including naming improvements for calibration parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sequential two-point calibration function blocks (`E_CALIBRATE_SQ`, `AR_CALIBRATE_SQ`) that enforce proper offset-then-scale execution order via state machine.

* **Bug Fixes**
  * Added zero-denominator safety guards in calibration algorithms to prevent division errors.

* **Documentation**
  * Enhanced calibration documentation across all function blocks with formulas, step-by-step procedures, and worked examples.
  * Clarified event sequencing requirements and assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->