### PR TITLE
Fix InterfaceList and BasicFB tag order in calibration function blocks

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_SQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/OSCAT/typelib/Basic/POUs/Engineering/measurements/E_CALIBRATE_SQ.fbt
@@ -50,12 +50,12 @@
 			<VarDeclaration Name="OFFSET" Type="REAL" Comment="Stored offset value" InitialValue="0.0"/>
 			<VarDeclaration Name="SCALE" Type="REAL" Comment="Stored scale value" InitialValue="1.0"/>
 		</InOutVars>
+	</InterfaceList>
+	<BasicFB>
 		<InternalVars>
 			<VarDeclaration Name="X_LOW_INT" Type="REAL" Comment="Stored raw value at CO"/>
 			<VarDeclaration Name="Y_LOW_INT" Type="REAL" Comment="Stored target value at CO"/>
 		</InternalVars>
-	</InterfaceList>
-	<BasicFB>
 		<ECC>
 			<ECState Name="START" x="-240" y="-160">
 			</ECState>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_SQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/Engineering/measurements/AR_CALIBRATE_SQ.fbt
@@ -27,12 +27,12 @@
 			<AdapterDeclaration Name="CO" Type="adapter::types::unidirectional::AX" Comment="Calibrate Offset"/>
 			<AdapterDeclaration Name="CS" Type="adapter::types::unidirectional::AX" Comment="Calibrate Scale"/>
 		</Sockets>
+	</InterfaceList>
+	<BasicFB>
 		<InternalVars>
 			<VarDeclaration Name="X_LOW_INT" Type="REAL" Comment="Stored raw value at CO"/>
 			<VarDeclaration Name="Y_LOW_INT" Type="REAL" Comment="Stored target value at CO"/>
 		</InternalVars>
-	</InterfaceList>
-	<BasicFB>
 		<ECC>
 			<ECState Name="IDLE" x="0" y="0">
 			</ECState>


### PR DESCRIPTION
Ensure proper XML structure by adjusting the tag order in AR_CALIBRATE_SQ.fbt and E_CALIBRATE_SQ.fbt. This change corrects the structure, likely to prevent parsing errors in function block definitions.

## Summary by Sourcery

Bug Fixes:
- Fix invalid tag ordering in AR_CALIBRATE_SQ.fbt and E_CALIBRATE_SQ.fbt that could cause XML parsing issues.