### PR TITLE
feat: introduce SETM for mirroring support in NVS and INI interfaces

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AB.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AB.fbt
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="NVS_AX2" Comment="Load and Store REAL Data from NVS by Key (AX2 Adapter Interface)">
+<FBType Name="NVS_AB" Comment="Load and Store BYTE Data from NVS by Key (AB Adapter Interface)">
 	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-24" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::storage::esp32_nvs">
 		<Import declaration="eclipse4diac::core::TypeHash"/>
-		<Import declaration="adapter::types::unidirectional::AR"/>
+		<Import declaration="adapter::types::unidirectional::AB"/>
 		<Import declaration="logiBUS::storage::esp32_nvs::NVS"/>
 	</CompilerInfo>
 	<InterfaceList>
@@ -28,14 +28,17 @@
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
 			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the NVS" InitialValue="FALSE"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BYTE" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="AB_OUT" Type="adapter::types::unidirectional::AB" Comment="Stored value output (GETO)" x="5100" y="3000"/>
+		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AX2" Comment="Value" x="4500" y="2800"/>
+			<AdapterDeclaration Name="AB_IN" Type="adapter::types::unidirectional::AB" Comment="Value to store (SET)" x="-900" y="1200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
@@ -45,11 +48,11 @@
 		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
-			<Connection Source="NVS.INITO" Destination="INITO" dx1="700"/>
+			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
-			<Connection Source="VAL.EO1" Destination="NVS.SET" dx1="893.33" dx2="713.33" dy="-1260"/>
-			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
-			<Connection Source="NVS.GETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="AB_IN.E1" Destination="NVS.SET" dx1="313.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AB_OUT.E1" dx1="420"/>
+			<Connection Source="NVS.GETO" Destination="AB_OUT.E1" dx1="700"/>
 			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
@@ -59,10 +62,10 @@
 			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
-			<Connection Source="VAL.DO1" Destination="NVS.VALUE" dx1="246.67" dx2="100" dy="300"/>
-			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="293.33"/>
-			<Connection Source="NVS.QO" Destination="QO" dx1="2600"/>
-			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2600"/>
+			<Connection Source="AB_IN.D1" Destination="NVS.VALUE" dx1="100"/>
+			<Connection Source="NVS.VALUEO" Destination="AB_OUT.D1" dx1="133.33"/>
+			<Connection Source="NVS.QO" Destination="QO" dx1="2613.33"/>
+			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2613.33"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AB2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AB2.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,8 +26,9 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the NVS"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BYTE" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
@@ -39,13 +41,16 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1400" y="2000">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="700"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="VAL.EO1" Destination="NVS.SET" dx1="893.33" dx2="713.33" dy="-1260"/>
-			<Connection Source="NVS.SETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
@@ -55,6 +60,9 @@
 			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="933.33"/>
 			<Connection Source="NVS.QO" Destination="QO" dx1="2600"/>
 			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2600"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AIS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AIS.fbt
@@ -11,6 +11,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -23,6 +24,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="STRING" Comment="The value to read if there is nothing in the settings.NVS"/>
 		</InputVars>
@@ -31,7 +33,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AIS_OUT" Type="adapter::types::unidirectional::AIS" Comment="Stored value output (GETO)" x="2900" y="300"/>
+			<AdapterDeclaration Name="AIS_OUT" Type="adapter::types::unidirectional::AIS" Comment="Stored value output (GETO)" x="3800" y="300"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="AIS_IN" Type="adapter::types::unidirectional::AIS" Comment="Value to store (SET)" x="-400" y="200"/>
@@ -40,22 +42,28 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="800" y="-1000">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="2400" y="-900">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="100"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="100"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="80" dx2="80" dy="-373.33"/>
 			<Connection Source="AIS_IN.E1" Destination="NVS.SET" dx1="100"/>
-			<Connection Source="NVS.SETO" Destination="AIS_OUT.E1" dx1="533.33"/>
-			<Connection Source="NVS.GETO" Destination="AIS_OUT.E1" dx1="533.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AIS_OUT.E1" dx1="366.67"/>
+			<Connection Source="NVS.GETO" Destination="AIS_OUT.E1" dx1="286.67"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="100"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="100"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="100">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="100"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="100"/>
 			<Connection Source="AIS_IN.D1" Destination="NVS.VALUE" dx1="580"/>
 			<Connection Source="NVS.VALUEO" Destination="AIS_OUT.D1" dx1="100"/>
-			<Connection Source="NVS.QO" Destination="QO" dx1="1566.67"/>
-			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="1566.67"/>
+			<Connection Source="NVS.QO" Destination="QO" dx1="2020"/>
+			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2240"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_ALR.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,6 +26,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="LREAL" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
@@ -42,16 +44,22 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="ALR_IN.E1" Destination="NVS.SET" dx1="313.33"/>
-			<Connection Source="NVS.SETO" Destination="ALR_OUT.E1" dx1="753.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="ALR_OUT.E1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="ALR_OUT.E1" dx1="753.33"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="ALR_IN.D1" Destination="NVS.VALUE" dx1="100"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AR.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,6 +26,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
@@ -42,16 +44,22 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AR_IN.E1" Destination="NVS.SET" dx1="313.33"/>
-			<Connection Source="NVS.SETO" Destination="AR_OUT.E1" dx1="700"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AR_OUT.E1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="AR_OUT.E1" dx1="700"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AR_IN.D1" Destination="NVS.VALUE" dx1="100"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AR2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AR2.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,6 +26,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
@@ -39,20 +41,26 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1400" y="2000">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="700"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="VAL.EO1" Destination="NVS.SET" dx1="893.33" dx2="713.33" dy="-1260"/>
-			<Connection Source="NVS.SETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="VAL.DO1" Destination="NVS.VALUE" dx1="246.67" dx2="100" dy="300"/>
-			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="933.33"/>
+			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="340"/>
 			<Connection Source="NVS.QO" Destination="QO" dx1="2600"/>
 			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2600"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AS.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,6 +26,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="SINT" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
@@ -42,16 +44,22 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AS_IN.E1" Destination="NVS.SET" dx1="313.33"/>
-			<Connection Source="NVS.SETO" Destination="AS_OUT.E1" dx1="753.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AS_OUT.E1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="AS_OUT.E1" dx1="753.33"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AS_IN.D1" Destination="NVS.VALUE" dx1="100"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AUDI.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,6 +26,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="UDINT" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
@@ -42,16 +44,22 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AUDI_IN.E1" Destination="NVS.SET" dx1="313.33"/>
-			<Connection Source="NVS.SETO" Destination="AUDI_OUT.E1" dx1="700"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AUDI_OUT.E1" dx1="120"/>
 			<Connection Source="NVS.GETO" Destination="AUDI_OUT.E1" dx1="700"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AUDI_IN.D1" Destination="NVS.VALUE" dx1="100"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AUI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AUI.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -25,8 +26,9 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="UDINT" Comment="The value to read if there is nothing in the NVS"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="UINT" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
@@ -42,15 +44,22 @@
 	<FBNetwork>
 		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
 			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AUI_IN.E1" Destination="NVS.SET" dx1="313.33"/>
-			<Connection Source="NVS.SETO" Destination="AUI_OUT.E1" dx1="700"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AUI_OUT.E1" dx1="120"/>
+			<Connection Source="NVS.GETO" Destination="AUI_OUT.E1" dx1="700"/>
+			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AUI_IN.D1" Destination="NVS.VALUE" dx1="100"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/esp32_nvs/NVS_AX.fbt
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="NVS_AX2" Comment="Load and Store REAL Data from NVS by Key (AX2 Adapter Interface)">
+<FBType Name="NVS_AX" Comment="Load and Store BOOL Data from NVS by Key (AX Adapter Interface)">
 	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-24" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::storage::esp32_nvs">
 		<Import declaration="eclipse4diac::core::TypeHash"/>
-		<Import declaration="adapter::types::unidirectional::AR"/>
+		<Import declaration="adapter::types::unidirectional::AX"/>
 		<Import declaration="logiBUS::storage::esp32_nvs::NVS"/>
 	</CompilerInfo>
 	<InterfaceList>
@@ -28,28 +28,31 @@
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
 			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the NVS" InitialValue="FALSE"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the NVS"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="AX_OUT" Type="adapter::types::unidirectional::AX" Comment="Stored value output (GETO)" x="4700" y="3000"/>
+		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AX2" Comment="Value" x="4500" y="2800"/>
+			<AdapterDeclaration Name="AX_IN" Type="adapter::types::unidirectional::AX" Comment="Value to store (SET)" x="-900" y="1200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1400" y="2000">
+		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1366.67" y="1940">
 		</FB>
 		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
 		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
-			<Connection Source="NVS.INITO" Destination="INITO" dx1="700"/>
+			<Connection Source="NVS.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
-			<Connection Source="VAL.EO1" Destination="NVS.SET" dx1="893.33" dx2="713.33" dy="-1260"/>
-			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
-			<Connection Source="NVS.GETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="AX_IN.E1" Destination="NVS.SET" dx1="313.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AX_OUT.E1" dx1="120"/>
+			<Connection Source="NVS.GETO" Destination="AX_OUT.E1" dx1="700"/>
 			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
@@ -59,10 +62,10 @@
 			</Connection>
 			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
-			<Connection Source="VAL.DO1" Destination="NVS.VALUE" dx1="246.67" dx2="100" dy="300"/>
-			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="293.33"/>
-			<Connection Source="NVS.QO" Destination="QO" dx1="2600"/>
-			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2600"/>
+			<Connection Source="AX_IN.D1" Destination="NVS.VALUE" dx1="100"/>
+			<Connection Source="NVS.VALUEO" Destination="AX_OUT.D1" dx1="133.33"/>
+			<Connection Source="NVS.QO" Destination="QO" dx1="2613.33"/>
+			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2613.33"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AB.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AB.fbt
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="NVS_AX2" Comment="Load and Store REAL Data from NVS by Key (AX2 Adapter Interface)">
+<FBType Name="INI_AB" Comment="Load and Store BYTE Data from settings.ini by Section and Key (AB Adapter Interface)">
 	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-24" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
-	<CompilerInfo packageName="logiBUS::storage::esp32_nvs">
+	<CompilerInfo packageName="eclipse4diac::storage">
 		<Import declaration="eclipse4diac::core::TypeHash"/>
-		<Import declaration="adapter::types::unidirectional::AR"/>
-		<Import declaration="logiBUS::storage::esp32_nvs::NVS"/>
+		<Import declaration="adapter::types::unidirectional::AB"/>
+		<Import declaration="eclipse4diac::storage::INI"/>
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
 				<With Var="SETM"/>
+				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
 			</Event>
@@ -27,42 +28,47 @@
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
 			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
+			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the NVS" InitialValue="FALSE"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BYTE" Comment="The value to read if there is nothing in the settings.ini"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="AB_OUT" Type="adapter::types::unidirectional::AB" Comment="Stored value output (GETO)" x="5100" y="3000"/>
+		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AX2" Comment="Value" x="4500" y="2800"/>
+			<AdapterDeclaration Name="AB_IN" Type="adapter::types::unidirectional::AB" Comment="Value to store (SET)" x="-100" y="1000"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="NVS" Type="logiBUS::storage::esp32_nvs::NVS" x="1400" y="2000">
+		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
 		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
 		</FB>
 		<EventConnections>
-			<Connection Source="INIT" Destination="NVS.INIT" dx1="333.33"/>
-			<Connection Source="NVS.INITO" Destination="INITO" dx1="700"/>
-			<Connection Source="NVS.INITO" Destination="NVS.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
-			<Connection Source="VAL.EO1" Destination="NVS.SET" dx1="893.33" dx2="713.33" dy="-1260"/>
-			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
-			<Connection Source="NVS.GETO" Destination="VAL.EI1" dx1="553.33"/>
-			<Connection Source="NVS.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
+			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
+			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
+			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
+			<Connection Source="AB_IN.E1" Destination="INI.SET" dx1="313.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AB_OUT.E1" dx1="120"/>
+			<Connection Source="INI.GETO" Destination="AB_OUT.E1" dx1="766.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="QI" Destination="NVS.QI" dx1="266.67"/>
+			<Connection Source="QI" Destination="INI.QI" dx1="333.33"/>
 			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
 				<Attribute Name="Visible" Value="false"/>
 			</Connection>
-			<Connection Source="KEY" Destination="NVS.KEY" dx1="200"/>
-			<Connection Source="DEFAULT_VALUE" Destination="NVS.DEFAULT_VALUE" dx1="66.67"/>
-			<Connection Source="VAL.DO1" Destination="NVS.VALUE" dx1="246.67" dx2="100" dy="300"/>
-			<Connection Source="NVS.VALUEO" Destination="VAL.DI1" dx1="293.33"/>
-			<Connection Source="NVS.QO" Destination="QO" dx1="2600"/>
-			<Connection Source="NVS.STATUS" Destination="STATUS" dx1="2600"/>
+			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
+			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
+			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
+			<Connection Source="AB_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
+			<Connection Source="INI.VALUEO" Destination="AB_OUT.D1" dx1="340"/>
+			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
+			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AB2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AB2.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,35 +27,42 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the settings.ini"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BYTE" Comment="The value to read if there is nothing in the settings.ini"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AB2" Comment="Value" x="4500" y="2600"/>
+			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AB2" Comment="Value" x="4800" y="2600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3800" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="700"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="VAL.EO1" Destination="INI.SET" dx1="140" dx2="713.33" dy="-1260"/>
-			<Connection Source="INI.SETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="220"/>
 			<Connection Source="INI.GETO" Destination="VAL.EI1" dx1="553.33"/>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="1558.82"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="788.24"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="VAL.DO1" Destination="INI.VALUE" dx1="246.67" dx2="100" dy="300"/>
-			<Connection Source="INI.VALUEO" Destination="VAL.DI1" dx1="933.33"/>
+			<Connection Source="INI.VALUEO" Destination="VAL.DI1" dx1="333.33"/>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="370.59"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="1246.67"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="966.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AIS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AIS.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="STRING" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,7 +37,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AIS_OUT" Type="adapter::types::unidirectional::AIS" Comment="Stored value output (GETO)" x="3000" y="1300"/>
+			<AdapterDeclaration Name="AIS_OUT" Type="adapter::types::unidirectional::AIS" Comment="Stored value output (GETO)" x="3900" y="1300"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="AIS_IN" Type="adapter::types::unidirectional::AIS" Comment="Value to store (SET)" x="-900" y="1100"/>
@@ -44,23 +46,29 @@
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1000" y="0">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="2600" y="100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="100"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="100"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="80" dx2="80" dy="-400"/>
 			<Connection Source="AIS_IN.E1" Destination="INI.SET" dx1="100"/>
 			<Connection Source="INI.GETO" Destination="AIS_OUT.E1" dx1="486.67"/>
-			<Connection Source="INI.SETO" Destination="AIS_OUT.E1" dx1="486.67"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AIS_OUT.E1" dx1="486.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="100"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="100"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="100">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="100"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="100"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="100"/>
 			<Connection Source="AIS_IN.D1" Destination="INI.VALUE" dx1="493.33"/>
 			<Connection Source="INI.VALUEO" Destination="AIS_OUT.D1" dx1="100"/>
-			<Connection Source="INI.QO" Destination="QO" dx1="1466.67"/>
-			<Connection Source="INI.STATUS" Destination="STATUS" dx1="1466.67"/>
+			<Connection Source="INI.QO" Destination="QO" dx1="1966.67"/>
+			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2093.33"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_ALR.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="LREAL" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,7 +37,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="ALR_OUT" Type="adapter::types::unidirectional::ALR" Comment="Stored value output (GETO)" x="4000" y="1800"/>
+			<AdapterDeclaration Name="ALR_OUT" Type="adapter::types::unidirectional::ALR" Comment="Stored value output (GETO)" x="5200" y="2800"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="ALR_IN" Type="adapter::types::unidirectional::ALR" Comment="Value to store (SET)" x="-100" y="1000"/>
@@ -44,21 +46,27 @@
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="ALR_IN.E1" Destination="INI.SET" dx1="313.33"/>
-			<Connection Source="INI.SETO" Destination="ALR_OUT.E1" dx1="766.67"/>
+			<Connection Source="SET_PERMIT.EO" Destination="ALR_OUT.E1" dx1="120"/>
 			<Connection Source="INI.GETO" Destination="ALR_OUT.E1" dx1="766.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="333.33"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="ALR_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
-			<Connection Source="INI.VALUEO" Destination="ALR_OUT.D1" dx1="1166.67"/>
+			<Connection Source="INI.VALUEO" Destination="ALR_OUT.D1" dx1="513.33"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AR.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,7 +37,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AR_OUT" Type="adapter::types::unidirectional::AR" Comment="Stored value output (GETO)" x="4000" y="1800"/>
+			<AdapterDeclaration Name="AR_OUT" Type="adapter::types::unidirectional::AR" Comment="Stored value output (GETO)" x="4900" y="2900"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="AR_IN" Type="adapter::types::unidirectional::AR" Comment="Value to store (SET)" x="-100" y="1000"/>
@@ -44,21 +46,27 @@
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AR_IN.E1" Destination="INI.SET" dx1="313.33"/>
-			<Connection Source="INI.SETO" Destination="AR_OUT.E1" dx1="766.67"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AR_OUT.E1" dx1="120"/>
 			<Connection Source="INI.GETO" Destination="AR_OUT.E1" dx1="766.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="333.33"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AR_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
-			<Connection Source="INI.VALUEO" Destination="AR_OUT.D1" dx1="1166.67"/>
+			<Connection Source="INI.VALUEO" Destination="AR_OUT.D1" dx1="520"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AR2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AR2.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="REAL" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,22 +37,28 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AR2" Comment="Value" x="4500" y="2600"/>
+			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AR2" Comment="Value" x="4800" y="2600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3800" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="700"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="VAL.EO1" Destination="INI.SET" dx1="140" dx2="713.33" dy="-1260"/>
-			<Connection Source="INI.SETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="166.67"/>
 			<Connection Source="INI.GETO" Destination="VAL.EI1" dx1="553.33"/>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="1558.82"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="788.24"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="VAL.DO1" Destination="INI.VALUE" dx1="246.67" dx2="100" dy="300"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AS.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="SINT" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,7 +37,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AS_OUT" Type="adapter::types::unidirectional::AS" Comment="Stored value output (GETO)" x="4000" y="1800"/>
+			<AdapterDeclaration Name="AS_OUT" Type="adapter::types::unidirectional::AS" Comment="Stored value output (GETO)" x="5100" y="3000"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="AS_IN" Type="adapter::types::unidirectional::AS" Comment="Value to store (SET)" x="-100" y="1000"/>
@@ -44,21 +46,27 @@
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AS_IN.E1" Destination="INI.SET" dx1="313.33"/>
-			<Connection Source="INI.SETO" Destination="AS_OUT.E1" dx1="766.67"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AS_OUT.E1" dx1="120"/>
 			<Connection Source="INI.GETO" Destination="AS_OUT.E1" dx1="766.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="333.33"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AS_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
-			<Connection Source="INI.VALUEO" Destination="AS_OUT.D1" dx1="1166.67"/>
+			<Connection Source="INI.VALUEO" Destination="AS_OUT.D1" dx1="380"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AUDI.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="UDINT" Comment="The value to read if there is nothing in the settings.ini"/>
@@ -35,7 +37,7 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AUDI_OUT" Type="adapter::types::unidirectional::AUDI" Comment="Stored value output (GETO)" x="4000" y="1800"/>
+			<AdapterDeclaration Name="AUDI_OUT" Type="adapter::types::unidirectional::AUDI" Comment="Stored value output (GETO)" x="5100" y="2800"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="AUDI_IN" Type="adapter::types::unidirectional::AUDI" Comment="Value to store (SET)" x="-100" y="1000"/>
@@ -44,21 +46,27 @@
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3600" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="AUDI_IN.E1" Destination="INI.SET" dx1="313.33"/>
-			<Connection Source="INI.SETO" Destination="AUDI_OUT.E1" dx1="766.67"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AUDI_OUT.E1" dx1="120"/>
 			<Connection Source="INI.GETO" Destination="AUDI_OUT.E1" dx1="766.67"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="333.33"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="AUDI_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
-			<Connection Source="INI.VALUEO" Destination="AUDI_OUT.D1" dx1="1166.67"/>
+			<Connection Source="INI.VALUEO" Destination="AUDI_OUT.D1" dx1="240"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AX.fbt
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="INI_AUI" Comment="Load and Store UINT Data from settings.ini by Section and Key (AUI Adapter Interface)">
+<FBType Name="INI_AX" Comment="Load and Store BOOL Data from settings.ini by Section and Key (AX Adapter Interface)">
 	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
-	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-13" Remarks="initial API and implementation and/or initial documentation">
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-24" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="eclipse4diac::storage">
 		<Import declaration="eclipse4diac::core::TypeHash"/>
-		<Import declaration="adapter::types::unidirectional::AUI"/>
+		<Import declaration="adapter::types::unidirectional::AX"/>
 		<Import declaration="eclipse4diac::storage::INI"/>
 	</CompilerInfo>
 	<InterfaceList>
@@ -30,31 +30,31 @@
 			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
-			<VarDeclaration Name="DEFAULT_VALUE" Type="UINT" Comment="The value to read if there is nothing in the settings.ini"/>
+			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the settings.ini"/>
 		</InputVars>
 		<OutputVars>
 			<VarDeclaration Name="QO" Type="BOOL" Comment="Event Output Qualifier"/>
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Plugs>
-			<AdapterDeclaration Name="AUI_OUT" Type="adapter::types::unidirectional::AUI" Comment="Stored value output (GETO)" x="4800" y="2900"/>
+			<AdapterDeclaration Name="AX_OUT" Type="adapter::types::unidirectional::AX" Comment="Stored value output (GETO)" x="5800" y="3000"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="AUI_IN" Type="adapter::types::unidirectional::AUI" Comment="Value to store (SET)" x="-100" y="1000"/>
+			<AdapterDeclaration Name="AX_IN" Type="adapter::types::unidirectional::AX" Comment="Value to store (SET)" x="-100" y="1000"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
-		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3700" y="2000">
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3900" y="2100">
 		</FB>
 		<EventConnections>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="400"/>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="200"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
-			<Connection Source="AUI_IN.E1" Destination="INI.SET" dx1="313.33"/>
-			<Connection Source="SET_PERMIT.EO" Destination="AUI_OUT.E1" dx1="220"/>
-			<Connection Source="INI.GETO" Destination="AUI_OUT.E1" dx1="766.67"/>
+			<Connection Source="AX_IN.E1" Destination="INI.SET" dx1="313.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="AX_OUT.E1" dx1="420"/>
+			<Connection Source="INI.GETO" Destination="AX_OUT.E1" dx1="766.67"/>
 			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
@@ -65,8 +65,8 @@
 			<Connection Source="SECTION" Destination="INI.SECTION" dx1="266.67"/>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
-			<Connection Source="AUI_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
-			<Connection Source="INI.VALUEO" Destination="AUI_OUT.D1" dx1="380"/>
+			<Connection Source="AX_IN.D1" Destination="INI.VALUE" dx1="113.33"/>
+			<Connection Source="INI.VALUEO" Destination="AX_OUT.D1" dx1="400"/>
 			<Connection Source="INI.QO" Destination="QO" dx1="2580"/>
 			<Connection Source="INI.STATUS" Destination="STATUS" dx1="2580"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AX2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI_AX2.fbt
@@ -13,6 +13,7 @@
 		<EventInputs>
 			<Event Name="INIT" Type="EInit" Comment="Service Initialization">
 				<With Var="QI"/>
+				<With Var="SETM"/>
 				<With Var="SECTION"/>
 				<With Var="KEY"/>
 				<With Var="DEFAULT_VALUE"/>
@@ -26,6 +27,7 @@
 		</EventOutputs>
 		<InputVars>
 			<VarDeclaration Name="QI" Type="BOOL" Comment="Event Input Qualifier"/>
+			<VarDeclaration Name="SETM" Type="BOOL" Comment="Enable Mirroring on SET"/>
 			<VarDeclaration Name="SECTION" Type="STRING" Comment="Section name."/>
 			<VarDeclaration Name="KEY" Type="STRING" Comment="Key name."/>
 			<VarDeclaration Name="DEFAULT_VALUE" Type="BOOL" Comment="The value to read if there is nothing in the settings.ini" InitialValue="FALSE"/>
@@ -35,22 +37,28 @@
 			<VarDeclaration Name="STATUS" Type="STRING" Comment="Service Status"/>
 		</OutputVars>
 		<Sockets>
-			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AX2" Comment="Value" x="4500" y="2600"/>
+			<AdapterDeclaration Name="VAL" Type="adapter::types::bidirectional::AX2" Comment="Value" x="4800" y="2600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="INI" Type="eclipse4diac::storage::INI" x="1433.33" y="1940">
 		</FB>
+		<FB Name="SET_PERMIT" Type="iec61499::events::E_PERMIT" x="3900" y="2100">
+		</FB>
 		<EventConnections>
 			<Connection Source="INI.INITO" Destination="INITO" dx1="700"/>
 			<Connection Source="INI.INITO" Destination="INI.GET" dx1="133.33" dx2="133.33" dy="-226.67"/>
 			<Connection Source="VAL.EO1" Destination="INI.SET" dx1="140" dx2="713.33" dy="-1260"/>
-			<Connection Source="INI.SETO" Destination="VAL.EI1" dx1="553.33"/>
+			<Connection Source="SET_PERMIT.EO" Destination="VAL.EI1" dx1="120"/>
 			<Connection Source="INI.GETO" Destination="VAL.EI1" dx1="553.33"/>
 			<Connection Source="INIT" Destination="INI.INIT" dx1="1558.82"/>
+			<Connection Source="INI.SETO" Destination="SET_PERMIT.EI" dx1="433.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="QI" Destination="INI.QI" dx1="788.24"/>
+			<Connection Source="SETM" Destination="SET_PERMIT.PERMIT" dx1="2746.67">
+				<Attribute Name="Visible" Value="false"/>
+			</Connection>
 			<Connection Source="KEY" Destination="INI.KEY" dx1="200"/>
 			<Connection Source="DEFAULT_VALUE" Destination="INI.DEFAULT_VALUE" dx1="66.67"/>
 			<Connection Source="VAL.DO1" Destination="INI.VALUE" dx1="246.67" dx2="100" dy="300"/>


### PR DESCRIPTION
Enable SETM variable across NVS and INI interfaces to support mirroring of data during set operations. This change also refines the connection logic to ensure consistent data handling and integrates a visibility attribute for better control flow management. Enhances existing storage capabilities by adding flexibility in data interactions.

## Summary by Sourcery

Introduce SETM-based mirroring support across ESP32 NVS and INI storage function blocks and extend coverage to additional AB/AX variants.

New Features:
- Add SETM-enabled ESP32 NVS storage function blocks for AB and AX variants to support mirrored set operations.
- Add SETM-enabled INI storage function blocks for AB and AX variants to support mirrored set operations across INI-based storage.

Enhancements:
- Update existing ESP32 NVS and INI storage function blocks to support SETM-based mirroring and improved data handling consistency.