### PR TITLE
Refactor counter function blocks to use event filters for on-change triggering

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ADI_FB_CTD" Comment="Down counter (DINT) ADI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CD, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_LD, E_D_FF_CD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="2900" y="1000"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTD_DINT" Type="iec61131::counters::FB_CTD_DINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="1900" y="1000">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
 		<EventConnections>
-			<Connection Source="LD.E1" Destination="FB_CTD_DINT.REQ" dx1="600"/>
-			<Connection Source="CD.E1" Destination="FB_CTD_DINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTD_DINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTD_DINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_DINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_DINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTD_DINT.REQ" dx1="600"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTD_DINT.REQ" dx1="800"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTD_DINT.REQ" dx1="213.33"/>
+			<Connection Source="FB_CTD_DINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="133.33"/>
+			<Connection Source="FB_CTD_DINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="LD.D1" Destination="FB_CTD_DINT.LD" dx1="200"/>
-			<Connection Source="CD.D1" Destination="FB_CTD_DINT.CD" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTD_DINT.PV" dx1="400"/>
-			<Connection Source="FB_CTD_DINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTD_DINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTD_DINT.LD" dx1="200"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTD_DINT.CD" dx1="693.33"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTD_DINT.PV" dx1="466.67"/>
+			<Connection Source="FB_CTD_DINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="100"/>
+			<Connection Source="FB_CTD_DINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTU.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTU.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ADI_FB_CTU" Comment="Up counter (DINT) ADI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CU, R, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_R). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTU_DINT" Type="iec61131::counters::FB_CTU_DINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="R.E1" Destination="FB_CTU_DINT.REQ" dx1="600"/>
-			<Connection Source="CU.E1" Destination="FB_CTU_DINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTU_DINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTU_DINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_DINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_DINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTU_DINT.REQ" dx1="513.33"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTU_DINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTU_DINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTU_DINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTU_DINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="446.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="R.D1" Destination="FB_CTU_DINT.R" dx1="200"/>
-			<Connection Source="CU.D1" Destination="FB_CTU_DINT.CU" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTU_DINT.PV" dx1="400"/>
-			<Connection Source="FB_CTU_DINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTU_DINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTU_DINT.CU" dx1="266.67"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTU_DINT.R" dx1="186.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTU_DINT.PV" dx1="420"/>
+			<Connection Source="FB_CTU_DINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTU_DINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="280"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTUD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ADI_FB_CTUD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ADI_FB_CTUD" Comment="Up-Down counter (DINT) ADI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1) on every update (CU, CD, R, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_QU, E_D_FF_QD, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_CD, E_D_FF_R, E_D_FF_LD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,46 +8,73 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="1400" y="-200"/>
-			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="1400" y="600"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="1400" y="1400"/>
+			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="2800" y="-200"/>
+			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="2800" y="600"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ADI" Comment="Count value" x="2800" y="1400"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="600"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="1400"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-1000" y="2200"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="600"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="1400"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ADI" Comment="Preset value" x="-2300" y="2200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTUD_DINT" Type="iec61131::counters::FB_CTUD_DINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="1400">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="2200">
+		</FB>
+		<FB Name="E_D_FF_QU" Type="iec61499::events::E_D_FF" x="2000" y="-200">
+		</FB>
+		<FB Name="E_D_FF_QD" Type="iec61499::events::E_D_FF" x="2000" y="600">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="1400">
+		</FB>
 		<EventConnections>
-			<Connection Source="CU.E1" Destination="FB_CTUD_DINT.REQ" dx1="1000"/>
-			<Connection Source="CD.E1" Destination="FB_CTUD_DINT.REQ" dx1="925"/>
-			<Connection Source="R.E1" Destination="FB_CTUD_DINT.REQ" dx1="850"/>
-			<Connection Source="LD.E1" Destination="FB_CTUD_DINT.REQ" dx1="775"/>
-			<Connection Source="PV.E1" Destination="FB_CTUD_DINT.REQ" dx1="700"/>
-			<Connection Source="FB_CTUD_DINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_DINT.CNF" Destination="QU.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_DINT.CNF" Destination="QD.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_DINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTUD_DINT.REQ" dx1="866.67"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTUD_DINT.REQ" dx1="446.67"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTUD_DINT.REQ" dx1="500"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTUD_DINT.REQ" dx1="500"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTUD_DINT.REQ" dx1="313.33"/>
+			<Connection Source="FB_CTUD_DINT.CNF" Destination="E_D_FF_QU.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_QU.EO" Destination="QU.E1"/>
+			<Connection Source="FB_CTUD_DINT.CNF" Destination="E_D_FF_QD.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_QD.EO" Destination="QD.E1"/>
+			<Connection Source="FB_CTUD_DINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="CU.D1" Destination="FB_CTUD_DINT.CU" dx1="500"/>
-			<Connection Source="CD.D1" Destination="FB_CTUD_DINT.CD" dx1="425"/>
-			<Connection Source="R.D1" Destination="FB_CTUD_DINT.R" dx1="350"/>
-			<Connection Source="LD.D1" Destination="FB_CTUD_DINT.LD" dx1="275"/>
-			<Connection Source="PV.D1" Destination="FB_CTUD_DINT.PV" dx1="200"/>
-			<Connection Source="FB_CTUD_DINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_DINT.QU" Destination="QU.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_DINT.QD" Destination="QD.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTUD_DINT.CU" dx1="833.33"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTUD_DINT.CD" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTUD_DINT.R" dx1="533.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTUD_DINT.LD" dx1="566.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTUD_DINT.PV" dx1="413.33"/>
+			<Connection Source="FB_CTUD_DINT.QU" Destination="E_D_FF_QU.D" dx1="433.33"/>
+			<Connection Source="E_D_FF_QU.Q" Destination="QU.D1"/>
+			<Connection Source="FB_CTUD_DINT.QD" Destination="E_D_FF_QD.D" dx1="433.33"/>
+			<Connection Source="E_D_FF_QD.Q" Destination="QD.D1"/>
+			<Connection Source="FB_CTUD_DINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="366.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AI_FB_CTD" Comment="Down counter (INT) AI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CD, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_LD, E_D_FF_CD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTD" Type="iec61131::counters::FB_CTD" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="LD.E1" Destination="FB_CTD.REQ" dx1="600"/>
-			<Connection Source="CD.E1" Destination="FB_CTD.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTD.REQ" dx1="800"/>
-			<Connection Source="FB_CTD.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTD.REQ" dx1="513.33"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTD.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTD.REQ" dx1="420"/>
+			<Connection Source="FB_CTD.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTD.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="566.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="LD.D1" Destination="FB_CTD.LD" dx1="200"/>
-			<Connection Source="CD.D1" Destination="FB_CTD.CD" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTD.PV" dx1="400"/>
-			<Connection Source="FB_CTD.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTD.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTD.CD" dx1="233.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTD.LD" dx1="260"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTD.PV" dx1="420"/>
+			<Connection Source="FB_CTD.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTD.CV" Destination="E_D_FF_ANY_CV.D" dx1="373.33"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTU.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTU.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AI_FB_CTU" Comment="Up counter (INT) AI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CU, R, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_R). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTU" Type="iec61131::counters::FB_CTU" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="R.E1" Destination="FB_CTU.REQ" dx1="600"/>
-			<Connection Source="CU.E1" Destination="FB_CTU.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTU.REQ" dx1="800"/>
-			<Connection Source="FB_CTU.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTU.REQ" dx1="513.33"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTU.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTU.REQ" dx1="420"/>
+			<Connection Source="FB_CTU.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTU.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="566.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="R.D1" Destination="FB_CTU.R" dx1="200"/>
-			<Connection Source="CU.D1" Destination="FB_CTU.CU" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTU.PV" dx1="400"/>
-			<Connection Source="FB_CTU.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTU.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTU.CU" dx1="380"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTU.R" dx1="353.33"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTU.PV" dx1="540"/>
+			<Connection Source="FB_CTU.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTU.CV" Destination="E_D_FF_ANY_CV.D" dx1="300"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTUD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AI_FB_CTUD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AI_FB_CTUD" Comment="Up-Down counter (INT) AI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1) on every update (CU, CD, R, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_QU, E_D_FF_QD, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_CD, E_D_FF_R, E_D_FF_LD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,46 +8,73 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="1400" y="-200"/>
-			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="1400" y="600"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="1400" y="1400"/>
+			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="2800" y="-200"/>
+			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="2800" y="600"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AI" Comment="Count value" x="2800" y="1400"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="600"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="1400"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-1000" y="2200"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="600"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="1400"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AI" Comment="Preset value" x="-2300" y="2200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTUD" Type="iec61131::counters::FB_CTUD" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="1400">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="2200">
+		</FB>
+		<FB Name="E_D_FF_QU" Type="iec61499::events::E_D_FF" x="2000" y="-200">
+		</FB>
+		<FB Name="E_D_FF_QD" Type="iec61499::events::E_D_FF" x="2000" y="600">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="1400">
+		</FB>
 		<EventConnections>
-			<Connection Source="CU.E1" Destination="FB_CTUD.REQ" dx1="1000"/>
-			<Connection Source="CD.E1" Destination="FB_CTUD.REQ" dx1="925"/>
-			<Connection Source="R.E1" Destination="FB_CTUD.REQ" dx1="850"/>
-			<Connection Source="LD.E1" Destination="FB_CTUD.REQ" dx1="775"/>
-			<Connection Source="PV.E1" Destination="FB_CTUD.REQ" dx1="700"/>
-			<Connection Source="FB_CTUD.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD.CNF" Destination="QU.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD.CNF" Destination="QD.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTUD.REQ" dx1="866.67"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTUD.REQ" dx1="446.67"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTUD.REQ" dx1="500"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTUD.REQ" dx1="500"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTUD.REQ" dx1="313.33"/>
+			<Connection Source="FB_CTUD.CNF" Destination="E_D_FF_QU.CLK" dx1="520"/>
+			<Connection Source="E_D_FF_QU.EO" Destination="QU.E1"/>
+			<Connection Source="FB_CTUD.CNF" Destination="E_D_FF_QD.CLK" dx1="520"/>
+			<Connection Source="E_D_FF_QD.EO" Destination="QD.E1"/>
+			<Connection Source="FB_CTUD.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="520"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="CU.D1" Destination="FB_CTUD.CU" dx1="500"/>
-			<Connection Source="CD.D1" Destination="FB_CTUD.CD" dx1="425"/>
-			<Connection Source="R.D1" Destination="FB_CTUD.R" dx1="350"/>
-			<Connection Source="LD.D1" Destination="FB_CTUD.LD" dx1="275"/>
-			<Connection Source="PV.D1" Destination="FB_CTUD.PV" dx1="200"/>
-			<Connection Source="FB_CTUD.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTUD.QU" Destination="QU.D1" dx1="100"/>
-			<Connection Source="FB_CTUD.QD" Destination="QD.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTUD.CU" dx1="833.33"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTUD.CD" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTUD.R" dx1="533.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTUD.LD" dx1="566.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTUD.PV" dx1="413.33"/>
+			<Connection Source="FB_CTUD.QU" Destination="E_D_FF_QU.D" dx1="553.33"/>
+			<Connection Source="E_D_FF_QU.Q" Destination="QU.D1"/>
+			<Connection Source="FB_CTUD.QD" Destination="E_D_FF_QD.D" dx1="553.33"/>
+			<Connection Source="E_D_FF_QD.Q" Destination="QD.D1"/>
+			<Connection Source="FB_CTUD.CV" Destination="E_D_FF_ANY_CV.D" dx1="486.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ALI_FB_CTD" Comment="Down counter (LINT) ALI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CD, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_LD, E_D_FF_CD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTD_LINT" Type="iec61131::counters::FB_CTD_LINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="LD.E1" Destination="FB_CTD_LINT.REQ" dx1="600"/>
-			<Connection Source="CD.E1" Destination="FB_CTD_LINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTD_LINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTD_LINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_LINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_LINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTD_LINT.REQ" dx1="513.33"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTD_LINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTD_LINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTD_LINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTD_LINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="446.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="LD.D1" Destination="FB_CTD_LINT.LD" dx1="200"/>
-			<Connection Source="CD.D1" Destination="FB_CTD_LINT.CD" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTD_LINT.PV" dx1="400"/>
-			<Connection Source="FB_CTD_LINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTD_LINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTD_LINT.CD" dx1="393.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTD_LINT.LD" dx1="300"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTD_LINT.PV" dx1="540"/>
+			<Connection Source="FB_CTD_LINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTD_LINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="326.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTU.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTU.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ALI_FB_CTU" Comment="Up counter (LINT) ALI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CU, R, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_R). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTU_LINT" Type="iec61131::counters::FB_CTU_LINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="R.E1" Destination="FB_CTU_LINT.REQ" dx1="600"/>
-			<Connection Source="CU.E1" Destination="FB_CTU_LINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTU_LINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTU_LINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_LINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_LINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTU_LINT.REQ" dx1="513.33"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTU_LINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTU_LINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTU_LINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTU_LINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="446.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="R.D1" Destination="FB_CTU_LINT.R" dx1="200"/>
-			<Connection Source="CU.D1" Destination="FB_CTU_LINT.CU" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTU_LINT.PV" dx1="400"/>
-			<Connection Source="FB_CTU_LINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTU_LINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTU_LINT.CU" dx1="406.67"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTU_LINT.R" dx1="326.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTU_LINT.PV" dx1="653.33"/>
+			<Connection Source="FB_CTU_LINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTU_LINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="173.33"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTUD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/ALI_FB_CTUD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="ALI_FB_CTUD" Comment="Up-Down counter (LINT) ALI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1) on every update (CU, CD, R, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_QU, E_D_FF_QD, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_CD, E_D_FF_R, E_D_FF_LD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,46 +8,73 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="1400" y="-200"/>
-			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="1400" y="600"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="1400" y="1400"/>
+			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="2800" y="-200"/>
+			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="2800" y="600"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::ALI" Comment="Count value" x="2800" y="1400"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="600"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="1400"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-1000" y="2200"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="600"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="1400"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::ALI" Comment="Preset value" x="-2300" y="2200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTUD_LINT" Type="iec61131::counters::FB_CTUD_LINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="1400">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="2200">
+		</FB>
+		<FB Name="E_D_FF_QU" Type="iec61499::events::E_D_FF" x="2000" y="-200">
+		</FB>
+		<FB Name="E_D_FF_QD" Type="iec61499::events::E_D_FF" x="2000" y="600">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="1400">
+		</FB>
 		<EventConnections>
-			<Connection Source="CU.E1" Destination="FB_CTUD_LINT.REQ" dx1="1000"/>
-			<Connection Source="CD.E1" Destination="FB_CTUD_LINT.REQ" dx1="925"/>
-			<Connection Source="R.E1" Destination="FB_CTUD_LINT.REQ" dx1="850"/>
-			<Connection Source="LD.E1" Destination="FB_CTUD_LINT.REQ" dx1="775"/>
-			<Connection Source="PV.E1" Destination="FB_CTUD_LINT.REQ" dx1="700"/>
-			<Connection Source="FB_CTUD_LINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_LINT.CNF" Destination="QU.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_LINT.CNF" Destination="QD.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_LINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTUD_LINT.REQ" dx1="866.67"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTUD_LINT.REQ" dx1="446.67"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTUD_LINT.REQ" dx1="500"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTUD_LINT.REQ" dx1="500"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTUD_LINT.REQ" dx1="313.33"/>
+			<Connection Source="FB_CTUD_LINT.CNF" Destination="E_D_FF_QU.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_QU.EO" Destination="QU.E1"/>
+			<Connection Source="FB_CTUD_LINT.CNF" Destination="E_D_FF_QD.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_QD.EO" Destination="QD.E1"/>
+			<Connection Source="FB_CTUD_LINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="400"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="CU.D1" Destination="FB_CTUD_LINT.CU" dx1="500"/>
-			<Connection Source="CD.D1" Destination="FB_CTUD_LINT.CD" dx1="425"/>
-			<Connection Source="R.D1" Destination="FB_CTUD_LINT.R" dx1="350"/>
-			<Connection Source="LD.D1" Destination="FB_CTUD_LINT.LD" dx1="275"/>
-			<Connection Source="PV.D1" Destination="FB_CTUD_LINT.PV" dx1="200"/>
-			<Connection Source="FB_CTUD_LINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_LINT.QU" Destination="QU.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_LINT.QD" Destination="QD.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTUD_LINT.CU" dx1="833.33"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTUD_LINT.CD" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTUD_LINT.R" dx1="533.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTUD_LINT.LD" dx1="566.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTUD_LINT.PV" dx1="413.33"/>
+			<Connection Source="FB_CTUD_LINT.QU" Destination="E_D_FF_QU.D" dx1="433.33"/>
+			<Connection Source="E_D_FF_QU.Q" Destination="QU.D1"/>
+			<Connection Source="FB_CTUD_LINT.QD" Destination="E_D_FF_QD.D" dx1="433.33"/>
+			<Connection Source="E_D_FF_QD.Q" Destination="QD.D1"/>
+			<Connection Source="FB_CTUD_LINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="366.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AUDI_FB_CTD" Comment="Down counter (UDINT) AUDI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CD, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_LD, E_D_FF_CD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTD_UDINT" Type="iec61131::counters::FB_CTD_UDINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="LD.E1" Destination="FB_CTD_UDINT.REQ" dx1="600"/>
-			<Connection Source="CD.E1" Destination="FB_CTD_UDINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTD_UDINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTD_UDINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_UDINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_UDINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTD_UDINT.REQ" dx1="513.33"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTD_UDINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTD_UDINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTD_UDINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTD_UDINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="426.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="LD.D1" Destination="FB_CTD_UDINT.LD" dx1="200"/>
-			<Connection Source="CD.D1" Destination="FB_CTD_UDINT.CD" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTD_UDINT.PV" dx1="400"/>
-			<Connection Source="FB_CTD_UDINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTD_UDINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTD_UDINT.CD" dx1="433.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTD_UDINT.LD" dx1="346.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTD_UDINT.PV" dx1="513.33"/>
+			<Connection Source="FB_CTD_UDINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTD_UDINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="266.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTU.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTU.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AUDI_FB_CTU" Comment="Up counter (UDINT) AUDI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CU, R, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_R). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTU_UDINT" Type="iec61131::counters::FB_CTU_UDINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="R.E1" Destination="FB_CTU_UDINT.REQ" dx1="600"/>
-			<Connection Source="CU.E1" Destination="FB_CTU_UDINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTU_UDINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTU_UDINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_UDINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_UDINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTU_UDINT.REQ" dx1="513.33"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTU_UDINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTU_UDINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTU_UDINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTU_UDINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="426.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="R.D1" Destination="FB_CTU_UDINT.R" dx1="200"/>
-			<Connection Source="CU.D1" Destination="FB_CTU_UDINT.CU" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTU_UDINT.PV" dx1="400"/>
-			<Connection Source="FB_CTU_UDINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTU_UDINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTU_UDINT.CU" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTU_UDINT.R" dx1="333.33"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTU_UDINT.PV" dx1="500"/>
+			<Connection Source="FB_CTU_UDINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTU_UDINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="206.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTUD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AUDI_FB_CTUD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AUDI_FB_CTUD" Comment="Up-Down counter (UDINT) AUDI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1) on every update (CU, CD, R, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_QU, E_D_FF_QD, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_CD, E_D_FF_R, E_D_FF_LD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,46 +8,73 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="1400" y="-200"/>
-			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="1400" y="600"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="1400" y="1400"/>
+			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="2800" y="-200"/>
+			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="2800" y="600"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AUDI" Comment="Count value" x="2800" y="1400"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="600"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="1400"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-1000" y="2200"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="600"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="1400"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AUDI" Comment="Preset value" x="-2300" y="2200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTUD_UDINT" Type="iec61131::counters::FB_CTUD_UDINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="1400">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="2200">
+		</FB>
+		<FB Name="E_D_FF_QU" Type="iec61499::events::E_D_FF" x="2000" y="-200">
+		</FB>
+		<FB Name="E_D_FF_QD" Type="iec61499::events::E_D_FF" x="2000" y="600">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="1400">
+		</FB>
 		<EventConnections>
-			<Connection Source="CU.E1" Destination="FB_CTUD_UDINT.REQ" dx1="1000"/>
-			<Connection Source="CD.E1" Destination="FB_CTUD_UDINT.REQ" dx1="925"/>
-			<Connection Source="R.E1" Destination="FB_CTUD_UDINT.REQ" dx1="850"/>
-			<Connection Source="LD.E1" Destination="FB_CTUD_UDINT.REQ" dx1="775"/>
-			<Connection Source="PV.E1" Destination="FB_CTUD_UDINT.REQ" dx1="700"/>
-			<Connection Source="FB_CTUD_UDINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_UDINT.CNF" Destination="QU.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_UDINT.CNF" Destination="QD.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_UDINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTUD_UDINT.REQ" dx1="866.67"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTUD_UDINT.REQ" dx1="446.67"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTUD_UDINT.REQ" dx1="500"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTUD_UDINT.REQ" dx1="500"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTUD_UDINT.REQ" dx1="313.33"/>
+			<Connection Source="FB_CTUD_UDINT.CNF" Destination="E_D_FF_QU.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_QU.EO" Destination="QU.E1"/>
+			<Connection Source="FB_CTUD_UDINT.CNF" Destination="E_D_FF_QD.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_QD.EO" Destination="QD.E1"/>
+			<Connection Source="FB_CTUD_UDINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="CU.D1" Destination="FB_CTUD_UDINT.CU" dx1="500"/>
-			<Connection Source="CD.D1" Destination="FB_CTUD_UDINT.CD" dx1="425"/>
-			<Connection Source="R.D1" Destination="FB_CTUD_UDINT.R" dx1="350"/>
-			<Connection Source="LD.D1" Destination="FB_CTUD_UDINT.LD" dx1="275"/>
-			<Connection Source="PV.D1" Destination="FB_CTUD_UDINT.PV" dx1="200"/>
-			<Connection Source="FB_CTUD_UDINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_UDINT.QU" Destination="QU.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_UDINT.QD" Destination="QD.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTUD_UDINT.CU" dx1="833.33"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTUD_UDINT.CD" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTUD_UDINT.R" dx1="533.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTUD_UDINT.LD" dx1="566.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTUD_UDINT.PV" dx1="413.33"/>
+			<Connection Source="FB_CTUD_UDINT.QU" Destination="E_D_FF_QU.D" dx1="413.33"/>
+			<Connection Source="E_D_FF_QU.Q" Destination="QU.D1"/>
+			<Connection Source="FB_CTUD_UDINT.QD" Destination="E_D_FF_QD.D" dx1="413.33"/>
+			<Connection Source="E_D_FF_QD.Q" Destination="QD.D1"/>
+			<Connection Source="FB_CTUD_UDINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="346.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AULI_FB_CTD" Comment="Down counter (ULINT) AULI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CD, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_LD, E_D_FF_CD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTD_ULINT" Type="iec61131::counters::FB_CTD_ULINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="LD.E1" Destination="FB_CTD_ULINT.REQ" dx1="600"/>
-			<Connection Source="CD.E1" Destination="FB_CTD_ULINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTD_ULINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTD_ULINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_ULINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTD_ULINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTD_ULINT.REQ" dx1="513.33"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTD_ULINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTD_ULINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTD_ULINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTD_ULINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="426.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="LD.D1" Destination="FB_CTD_ULINT.LD" dx1="200"/>
-			<Connection Source="CD.D1" Destination="FB_CTD_ULINT.CD" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTD_ULINT.PV" dx1="400"/>
-			<Connection Source="FB_CTD_ULINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTD_ULINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTD_ULINT.CD" dx1="433.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTD_ULINT.LD" dx1="326.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTD_ULINT.PV" dx1="573.33"/>
+			<Connection Source="FB_CTD_ULINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTD_ULINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="306.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTU.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTU.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AULI_FB_CTU" Comment="Up counter (ULINT) AULI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output event (Q.E1) on every update (CU, R, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (Q.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_Q, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_R). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,37 +8,52 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="1400" y="100"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="1400" y="893.33"/>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2800" y="100"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="2800" y="893.33"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-1000" y="600"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-2300" y="600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTU_ULINT" Type="iec61131::counters::FB_CTU_ULINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_Q" Type="iec61499::events::E_D_FF" x="2000" y="100">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="893">
+		</FB>
 		<EventConnections>
-			<Connection Source="R.E1" Destination="FB_CTU_ULINT.REQ" dx1="600"/>
-			<Connection Source="CU.E1" Destination="FB_CTU_ULINT.REQ" dx1="800"/>
-			<Connection Source="PV.E1" Destination="FB_CTU_ULINT.REQ" dx1="800"/>
-			<Connection Source="FB_CTU_ULINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_ULINT.CNF" Destination="Q.E1" dx1="133.33"/>
-			<Connection Source="FB_CTU_ULINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTU_ULINT.REQ" dx1="513.33"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTU_ULINT.REQ" dx1="513.33"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTU_ULINT.REQ" dx1="420"/>
+			<Connection Source="FB_CTU_ULINT.CNF" Destination="E_D_FF_Q.CLK"/>
+			<Connection Source="E_D_FF_Q.EO" Destination="Q.E1"/>
+			<Connection Source="FB_CTU_ULINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="426.67"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="R.D1" Destination="FB_CTU_ULINT.R" dx1="200"/>
-			<Connection Source="CU.D1" Destination="FB_CTU_ULINT.CU" dx1="400"/>
-			<Connection Source="PV.D1" Destination="FB_CTU_ULINT.PV" dx1="400"/>
-			<Connection Source="FB_CTU_ULINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTU_ULINT.Q" Destination="Q.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTU_ULINT.CU" dx1="386.67"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTU_ULINT.R" dx1="340"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTU_ULINT.PV" dx1="560"/>
+			<Connection Source="FB_CTU_ULINT.Q" Destination="E_D_FF_Q.D"/>
+			<Connection Source="E_D_FF_Q.Q" Destination="Q.D1"/>
+			<Connection Source="FB_CTU_ULINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="246.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTUD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/counters/AULI_FB_CTUD.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AULI_FB_CTUD" Comment="Up-Down counter (ULINT) AULI-Adapter Version">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1) on every update (CU, CD, R, LD, PV). If on-change triggering is required, use of an AX_D_FF as a filter is recommended.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 &#10; &#10;NOTE: This block fires the AX output events (QU.E1, QD.E1, CV.E1, etc.) only on value changes using the internal E_D_FF_* change-driven wiring (e.g., E_D_FF_QU, E_D_FF_QD, E_D_FF_ANY_PV, E_D_FF_CU, E_D_FF_CD, E_D_FF_R, E_D_FF_LD). External filtering is no longer required.">
 	</Identification>
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-21" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
@@ -8,46 +8,73 @@
 		<Import declaration="eclipse4diac::core::TypeHash"/>
 	</CompilerInfo>
 	<InterfaceList>
-		<EventOutputs>
-			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
-			</Event>
-		</EventOutputs>
 		<Plugs>
-			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="1400" y="-200"/>
-			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="1400" y="600"/>
-			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="1400" y="1400"/>
+			<AdapterDeclaration Name="QU" Type="adapter::types::unidirectional::AX" Comment="Output Up" x="2800" y="-200"/>
+			<AdapterDeclaration Name="QD" Type="adapter::types::unidirectional::AX" Comment="Output Down" x="2800" y="600"/>
+			<AdapterDeclaration Name="CV" Type="adapter::types::unidirectional::AULI" Comment="Count value" x="2800" y="1400"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-1000" y="-1000"/>
-			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-1000" y="-200"/>
-			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-1000" y="600"/>
-			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-1000" y="1400"/>
-			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-1000" y="2200"/>
+			<AdapterDeclaration Name="CU" Type="adapter::types::unidirectional::AX" Comment="Count up" x="-2300" y="-1000"/>
+			<AdapterDeclaration Name="CD" Type="adapter::types::unidirectional::AX" Comment="Count down" x="-2300" y="-200"/>
+			<AdapterDeclaration Name="R" Type="adapter::types::unidirectional::AX" Comment="Reset" x="-2300" y="600"/>
+			<AdapterDeclaration Name="LD" Type="adapter::types::unidirectional::AX" Comment="Load" x="-2300" y="1400"/>
+			<AdapterDeclaration Name="PV" Type="adapter::types::unidirectional::AULI" Comment="Preset value" x="-2300" y="2200"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<FB Name="FB_CTUD_ULINT" Type="iec61131::counters::FB_CTUD_ULINT" x="300" y="100">
 		</FB>
+		<FB Name="E_D_FF_CU" Type="iec61499::events::E_D_FF" x="-1300" y="-1000">
+		</FB>
+		<FB Name="E_D_FF_CD" Type="iec61499::events::E_D_FF" x="-1300" y="-200">
+		</FB>
+		<FB Name="E_D_FF_R" Type="iec61499::events::E_D_FF" x="-1300" y="600">
+		</FB>
+		<FB Name="E_D_FF_LD" Type="iec61499::events::E_D_FF" x="-1300" y="1400">
+		</FB>
+		<FB Name="E_D_FF_ANY_PV" Type="iec61499::events::E_D_FF_ANY" x="-1300" y="2200">
+		</FB>
+		<FB Name="E_D_FF_QU" Type="iec61499::events::E_D_FF" x="2000" y="-200">
+		</FB>
+		<FB Name="E_D_FF_QD" Type="iec61499::events::E_D_FF" x="2000" y="600">
+		</FB>
+		<FB Name="E_D_FF_ANY_CV" Type="iec61499::events::E_D_FF_ANY" x="2000" y="1400">
+		</FB>
 		<EventConnections>
-			<Connection Source="CU.E1" Destination="FB_CTUD_ULINT.REQ" dx1="1000"/>
-			<Connection Source="CD.E1" Destination="FB_CTUD_ULINT.REQ" dx1="925"/>
-			<Connection Source="R.E1" Destination="FB_CTUD_ULINT.REQ" dx1="850"/>
-			<Connection Source="LD.E1" Destination="FB_CTUD_ULINT.REQ" dx1="775"/>
-			<Connection Source="PV.E1" Destination="FB_CTUD_ULINT.REQ" dx1="700"/>
-			<Connection Source="FB_CTUD_ULINT.CNF" Destination="CV.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_ULINT.CNF" Destination="QU.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_ULINT.CNF" Destination="QD.E1" dx1="133.33"/>
-			<Connection Source="FB_CTUD_ULINT.CNF" Destination="CNF" dx1="133.33"/>
+			<Connection Source="CU.E1" Destination="E_D_FF_CU.CLK"/>
+			<Connection Source="E_D_FF_CU.EO" Destination="FB_CTUD_ULINT.REQ" dx1="866.67"/>
+			<Connection Source="CD.E1" Destination="E_D_FF_CD.CLK"/>
+			<Connection Source="E_D_FF_CD.EO" Destination="FB_CTUD_ULINT.REQ" dx1="446.67"/>
+			<Connection Source="R.E1" Destination="E_D_FF_R.CLK"/>
+			<Connection Source="E_D_FF_R.EO" Destination="FB_CTUD_ULINT.REQ" dx1="500"/>
+			<Connection Source="LD.E1" Destination="E_D_FF_LD.CLK"/>
+			<Connection Source="E_D_FF_LD.EO" Destination="FB_CTUD_ULINT.REQ" dx1="500"/>
+			<Connection Source="PV.E1" Destination="E_D_FF_ANY_PV.CLK"/>
+			<Connection Source="E_D_FF_ANY_PV.EO" Destination="FB_CTUD_ULINT.REQ" dx1="313.33"/>
+			<Connection Source="FB_CTUD_ULINT.CNF" Destination="E_D_FF_QU.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_QU.EO" Destination="QU.E1"/>
+			<Connection Source="FB_CTUD_ULINT.CNF" Destination="E_D_FF_QD.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_QD.EO" Destination="QD.E1"/>
+			<Connection Source="FB_CTUD_ULINT.CNF" Destination="E_D_FF_ANY_CV.CLK" dx1="380"/>
+			<Connection Source="E_D_FF_ANY_CV.EO" Destination="CV.E1"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="CU.D1" Destination="FB_CTUD_ULINT.CU" dx1="500"/>
-			<Connection Source="CD.D1" Destination="FB_CTUD_ULINT.CD" dx1="425"/>
-			<Connection Source="R.D1" Destination="FB_CTUD_ULINT.R" dx1="350"/>
-			<Connection Source="LD.D1" Destination="FB_CTUD_ULINT.LD" dx1="275"/>
-			<Connection Source="PV.D1" Destination="FB_CTUD_ULINT.PV" dx1="200"/>
-			<Connection Source="FB_CTUD_ULINT.CV" Destination="CV.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_ULINT.QU" Destination="QU.D1" dx1="100"/>
-			<Connection Source="FB_CTUD_ULINT.QD" Destination="QD.D1" dx1="100"/>
+			<Connection Source="CU.D1" Destination="E_D_FF_CU.D"/>
+			<Connection Source="E_D_FF_CU.Q" Destination="FB_CTUD_ULINT.CU" dx1="833.33"/>
+			<Connection Source="CD.D1" Destination="E_D_FF_CD.D"/>
+			<Connection Source="E_D_FF_CD.Q" Destination="FB_CTUD_ULINT.CD" dx1="413.33"/>
+			<Connection Source="R.D1" Destination="E_D_FF_R.D"/>
+			<Connection Source="E_D_FF_R.Q" Destination="FB_CTUD_ULINT.R" dx1="533.33"/>
+			<Connection Source="LD.D1" Destination="E_D_FF_LD.D"/>
+			<Connection Source="E_D_FF_LD.Q" Destination="FB_CTUD_ULINT.LD" dx1="566.67"/>
+			<Connection Source="PV.D1" Destination="E_D_FF_ANY_PV.D"/>
+			<Connection Source="E_D_FF_ANY_PV.Q" Destination="FB_CTUD_ULINT.PV" dx1="413.33"/>
+			<Connection Source="FB_CTUD_ULINT.QU" Destination="E_D_FF_QU.D" dx1="413.33"/>
+			<Connection Source="E_D_FF_QU.Q" Destination="QU.D1"/>
+			<Connection Source="FB_CTUD_ULINT.QD" Destination="E_D_FF_QD.D" dx1="413.33"/>
+			<Connection Source="E_D_FF_QD.Q" Destination="QD.D1"/>
+			<Connection Source="FB_CTUD_ULINT.CV" Destination="E_D_FF_ANY_CV.D" dx1="346.67"/>
+			<Connection Source="E_D_FF_ANY_CV.Q" Destination="CV.D1"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Integrates event-driven flip-flops (E_D_FF) to optimize the execution flow of counter function blocks. This change allows for filtering and improved event handling by firing output events (e.g., QU.E1, QD.E1) only on state changes. Adds new up-down counter types in various formats to enhance functionality.

## Summary by Sourcery

Enhancements:
- Optimize CTU, CTD, and CTUD counter function blocks to emit output events only on state changes using event-filtered, event-driven logic across all adapter and array/list variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes / Improvements**
  * Counter blocks now emit output events only on value changes, reducing unnecessary event notifications and improving system efficiency.
  * All counter blocks across data types (DINT, LINT, UDINT, ULINT) updated with refined event-handling logic; external event filtering no longer required.
  * Counter interface layouts adjusted for improved visual organization.

* **Breaking Changes**
  * Confirmation event output (CNF) removed from all counter blocks' public interfaces; applications relying on this output require updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->