### PR TITLE
refactor: update PWM value import to use NumberVariable_PWM_Value

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q1_AX.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q1_AX.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-20" Remarks="initial API and implementation (Adapter Version)">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q1"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -17,7 +17,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_IDA" x="-2000" y="900">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;Ereignis erscheint erst im Adapter, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-2000" y="1800" width="1480" height="800"/>
 		<AdapterConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q2_AX.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q2_AX.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-20" Remarks="initial API and implementation (Adapter Version)">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q2"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -17,7 +17,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_IDA" x="-2000" y="900">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;Ereignis erscheint erst im Adapter, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-2000" y="1800" width="1480" height="800"/>
 		<AdapterConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q4_AX.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_034a1_Q4_AX.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2026-04-20" Remarks="initial API and implementation (Adapter Version)">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q4"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -17,7 +17,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_IDA" x="-2000" y="900">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;Ereignis erscheint erst im Adapter, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-2000" y="1800" width="1480" height="800"/>
 		<AdapterConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/test_AX.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/test_AX.sys
@@ -9,7 +9,7 @@
 	</CompilerInfo>
 	<Application Name="App_AX" Comment="Default App for Everything">
 		<SubAppNetwork>
-			<SubApp Name="Control" Type="Uebungen::Uebung_201_AX" x="3100" y="0">
+			<SubApp Name="Control" Type="Uebungen::Uebung_034a1_Q1_AX" x="3100" y="0">
 			</SubApp>
 		</SubAppNetwork>
 	</Application>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q1.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q1.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q1"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -19,7 +19,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_ID" x="-4000" y="900">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;IND erscheint erst, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-5900" y="700" width="1480" height="800"/>
 		<EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q2.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q2.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q2"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -19,7 +19,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_ID" x="-4000" y="1000">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;IND erscheint erst, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-5800" y="700" width="1480" height="800"/>
 		<EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q4.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_034a1_Q4.SUB
@@ -5,7 +5,7 @@
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
 	</VersionInfo>
 	<CompilerInfo packageName="Uebungen">
-		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::InputNumber_PWM_Value"/>
+		<Import declaration="Uebungen::const::UT::PWM::DefaultPool_PWM::NumberVariable_PWM_Value"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q4"/>
 	</CompilerInfo>
 	<SubAppInterfaceList>
@@ -19,7 +19,7 @@
 		</FB>
 		<FB Name="PWM_Value" Type="isobus::UT::io::NumericValue::NumericValue_ID" x="-3800" y="1000">
 			<Parameter Name="QI" Value="TRUE"/>
-			<Parameter Name="u16ObjId" Value="InputNumber_PWM_Value"/>
+			<Parameter Name="u16ObjId" Value="NumberVariable_PWM_Value"/>
 		</FB>
 		<Comment Comment="ACHTUNG !! &#10;IND erscheint erst, &#10;wenn man die Numeric Value mit OK Bestätigt. &#10;nicht bei Button Druck. &#10;" x="-5800" y="700" width="1480" height="800"/>
 		<EventConnections>


### PR DESCRIPTION
Updates the import declaration and parameter values to replace "InputNumber_PWM_Value" with "NumberVariable_PWM_Value" across multiple sub-applications. This change standardizes the usage and likely aligns variable naming with new conventions or requirements.

## Summary by Sourcery

Enhancements:
- Replace legacy InputNumber_PWM_Value imports and usages with NumberVariable_PWM_Value across affected exercise sub-applications for consistent naming and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PWM output control exercise configurations across multiple test scenarios to align data source references for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->