### PR TITLE
fix: change package name to booleanOperators

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AX_NOT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AX_NOT.fbt
@@ -19,11 +19,11 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="F_NOT_BOOL" Type="iec61131::bitwiseOperators::F_NOT_BOOL" x="1400" y="1100">
+		<FB Name="F_NOT_BOOL" Type="iec61131::booleanOperators::F_NOT_BOOL" x="1400" y="1100">
 		</FB>
 		<EventConnections>
-			<Connection Source="F_NOT_BOOL.CNF" Destination="OUT.E1"/>
-			<Connection Source="IN.E1" Destination="F_NOT_BOOL.REQ"/>
+			<Connection Source="F_NOT_BOOL.CNF" Destination="OUT.E1" dx1="433.33"/>
+			<Connection Source="IN.E1" Destination="F_NOT_BOOL.REQ" dx1="406.67"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="F_NOT_BOOL.OUT" Destination="OUT.D1"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AX_NOT_INIT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AX_NOT_INIT.fbt
@@ -27,11 +27,11 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="F_NOT_BOOL" Type="iec61131::bitwiseOperators::F_NOT_BOOL" x="1400" y="1100">
+		<FB Name="F_NOT_BOOL" Type="iec61131::booleanOperators::F_NOT_BOOL" x="1400" y="1100">
 		</FB>
 		<EventConnections>
-			<Connection Source="F_NOT_BOOL.CNF" Destination="OUT.E1"/>
-			<Connection Source="IN.E1" Destination="F_NOT_BOOL.REQ"/>
+			<Connection Source="F_NOT_BOOL.CNF" Destination="OUT.E1" dx1="433.33"/>
+			<Connection Source="IN.E1" Destination="F_NOT_BOOL.REQ" dx1="406.67"/>
 			<Connection Source="INIT" Destination="INITO"/>
 			<Connection Source="INIT" Destination="F_NOT_BOOL.REQ" dx1="3513.33"/>
 		</EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_10_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_10_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -44,6 +44,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_2_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_2_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2025-03-04" Remarks="copy AND_2 and made AND_2_BOOL">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -28,6 +28,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_3_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_3_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2025-03-04" Remarks="copy AND_2 and made AND_2_BOOL">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -30,6 +30,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_4_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_4_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -32,6 +32,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_5_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_5_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -34,6 +34,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_6_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_6_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -36,6 +36,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_7_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_7_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -38,6 +38,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_8_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_8_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -40,6 +40,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_9_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/AND_9_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -42,6 +42,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="AND result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AND_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/F_NOT_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/F_NOT_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/F_NOT_BOOL_INIT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/F_NOT_BOOL_INIT.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/INIT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/INIT.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/NOOP.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/NOOP.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Version="1.0" Author="franz" Date="2026-05-05">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/NOOP_INIT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/NOOP_INIT.fbt
@@ -4,7 +4,7 @@
 	</Identification>
 	<VersionInfo Version="1.0" Author="franz" Date="2026-05-05">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_10_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_10_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -44,6 +44,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_16_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_16_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -56,6 +56,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_2_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_2_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2025-03-04" Remarks="copy OR_2 and made OR_2_BOOL">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -28,6 +28,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_3_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_3_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.1" Author="Franz Höpfinger" Date="2025-03-04" Remarks="copy OR_2 and made OR_2_BOOL">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -30,6 +30,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_4_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_4_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -32,6 +32,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_5_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_5_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -34,6 +34,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_6_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_6_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -36,6 +36,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_7_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_7_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -38,6 +38,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_8_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_8_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -40,6 +40,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_9_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/OR_9_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -42,6 +42,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="OR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_OR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_10_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_10_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -44,6 +44,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_2_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_2_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -28,6 +28,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_3_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_3_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -30,6 +30,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_4_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_4_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -32,6 +32,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_5_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_5_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -34,6 +34,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_6_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_6_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -36,6 +36,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_7_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_7_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -38,6 +38,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_8_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_8_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -40,6 +40,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_9_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/iec61131-3-bool-3.0.0/typelib/booleanOperators/XOR_9_BOOL.fbt
@@ -6,7 +6,7 @@
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
 	</VersionInfo>
-	<CompilerInfo packageName="iec61131::bitwiseOperators">
+	<CompilerInfo packageName="iec61131::booleanOperators">
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
@@ -42,6 +42,6 @@
 			<VarDeclaration Name="OUT" Type="BOOL" Comment="XOR result"/>
 		</OutputVars>
 	</InterfaceList>
-	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR'"/>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_XOR_BOOL'"/>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/bypass/BYPASS_AX_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/bypass/BYPASS_AX_AX.fbt
@@ -17,15 +17,15 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-300" y="1600">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="-300" y="1600">
 		</FB>
 		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="1000" y="1600">
 		</FB>
 		<EventConnections>
 			<Connection Source="IN.E1" Destination="OUT.E1"/>
-			<Connection Source="BY_IN.E1" Destination="OR_2_BOOL.REQ"/>
+			<Connection Source="BY_IN.E1" Destination="OR_2_BOOL.REQ" dx1="460"/>
 			<Connection Source="IN.E1" Destination="OR_2_BOOL.REQ" dx1="460"/>
-			<Connection Source="OR_2_BOOL.CNF" Destination="E_D_FF.CLK"/>
+			<Connection Source="OR_2_BOOL.CNF" Destination="E_D_FF.CLK" dx1="353.33"/>
 			<Connection Source="E_D_FF.EO" Destination="BY_OUT.E1"/>
 		</EventConnections>
 		<DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/bypass/BYPASS_AX_BOOL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/bypass/BYPASS_AX_BOOL.fbt
@@ -31,13 +31,13 @@
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-3700" y="1100">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="-3700" y="1100">
 		</FB>
 		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="-2400" y="1100">
 		</FB>
 		<EventConnections>
-			<Connection Source="OR_2_BOOL.CNF" Destination="E_D_FF.CLK"/>
-			<Connection Source="BY_IN.E1" Destination="OR_2_BOOL.REQ"/>
+			<Connection Source="OR_2_BOOL.CNF" Destination="E_D_FF.CLK" dx1="353.33"/>
+			<Connection Source="BY_IN.E1" Destination="OR_2_BOOL.REQ" dx1="260"/>
 			<Connection Source="E_D_FF.EO" Destination="BY_OUT.E1"/>
 			<Connection Source="REQ" Destination="CNF"/>
 			<Connection Source="REQ" Destination="OR_2_BOOL.REQ" dx1="3082.35"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_RS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_RS.fbt
@@ -37,19 +37,19 @@
 	<FBNetwork>
 		<FB Name="FB_RS" Type="iec61131::bistableElements::FB_RS" x="1100" y="200">
 		</FB>
-		<FB Name="OR_2_BOOL_OUT" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-2700" y="2200">
+		<FB Name="OR_2_BOOL_OUT" Type="iec61131::booleanOperators::OR_2_BOOL" x="-2700" y="2200">
 		</FB>
-		<FB Name="OR_2_BOOL_IN" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-2700" y="1300">
+		<FB Name="OR_2_BOOL_IN" Type="iec61131::booleanOperators::OR_2_BOOL" x="-2700" y="1300">
 		</FB>
-		<FB Name="OR_3_BOOL" Type="iec61131::bitwiseOperators::OR_3_BOOL" x="-200" y="600">
+		<FB Name="OR_3_BOOL" Type="iec61131::booleanOperators::OR_3_BOOL" x="-200" y="600">
 		</FB>
 		<EventConnections>
 			<Connection Source="REQ" Destination="OR_3_BOOL.REQ" dx1="2246.67"/>
 			<Connection Source="FB_RS.CNF" Destination="CNF" dx1="1726.67"/>
-			<Connection Source="ILOCK_OUT.EI1" Destination="OR_2_BOOL_IN.REQ" dx1="133.33" dx2="100" dy="-346.67"/>
-			<Connection Source="OR_2_BOOL_IN.CNF" Destination="ILOCK_IN.EI1"/>
-			<Connection Source="OR_2_BOOL_OUT.CNF" Destination="ILOCK_OUT.EO1"/>
-			<Connection Source="ILOCK_IN.EO1" Destination="OR_2_BOOL_OUT.REQ" dx1="100" dx2="166.67" dy="620"/>
+			<Connection Source="ILOCK_OUT.EI1" Destination="OR_2_BOOL_IN.REQ" dx1="133.33" dx2="133.33" dy="-346.67"/>
+			<Connection Source="OR_2_BOOL_IN.CNF" Destination="ILOCK_IN.EI1" dx1="206.67"/>
+			<Connection Source="OR_2_BOOL_OUT.CNF" Destination="ILOCK_OUT.EO1" dx1="200"/>
+			<Connection Source="ILOCK_IN.EO1" Destination="OR_2_BOOL_OUT.REQ" dx1="100" dx2="100" dy="620"/>
 			<Connection Source="REQ" Destination="OR_2_BOOL_OUT.REQ" dx1="2246.67"/>
 			<Connection Source="REQ" Destination="OR_2_BOOL_IN.REQ" dx1="2246.67"/>
 			<Connection Source="OR_3_BOOL.CNF" Destination="FB_RS.REQ" dx1="280"/>
@@ -60,9 +60,9 @@
 			<Connection Source="S" Destination="FB_RS.S" dx1="5900"/>
 			<Connection Source="R1" Destination="OR_3_BOOL.IN1" dx1="2280"/>
 			<Connection Source="FB_RS.Q1" Destination="Q1" dx1="1726.67"/>
-			<Connection Source="ILOCK_IN.DO1" Destination="OR_2_BOOL_OUT.IN1" dx1="66.67" dx2="200" dy="373.33"/>
+			<Connection Source="ILOCK_IN.DO1" Destination="OR_2_BOOL_OUT.IN1" dx1="66.67" dx2="66.67" dy="373.33"/>
 			<Connection Source="OR_2_BOOL_OUT.OUT" Destination="ILOCK_OUT.DO1"/>
-			<Connection Source="ILOCK_OUT.DI1" Destination="OR_2_BOOL_IN.IN2" dx1="200" dx2="66.67" dy="-593.33"/>
+			<Connection Source="ILOCK_OUT.DI1" Destination="OR_2_BOOL_IN.IN2" dx1="200" dx2="200" dy="-593.33"/>
 			<Connection Source="OR_2_BOOL_IN.OUT" Destination="ILOCK_IN.DI1"/>
 			<Connection Source="R1" Destination="OR_2_BOOL_IN.IN1" dx1="2280"/>
 			<Connection Source="R1" Destination="OR_2_BOOL_OUT.IN2" dx1="2280"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_SR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/signalprocessing/interlock/ILOCK_FB_SR.fbt
@@ -37,22 +37,22 @@
 	<FBNetwork>
 		<FB Name="FB_SR" Type="iec61131::bistableElements::FB_SR" x="5000" y="300">
 		</FB>
-		<FB Name="OR_2_BOOL_OUT" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="1500" y="2400">
+		<FB Name="OR_2_BOOL_OUT" Type="iec61131::booleanOperators::OR_2_BOOL" x="1500" y="2400">
 		</FB>
-		<FB Name="OR_2_BOOL_IN" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="1500" y="1500">
+		<FB Name="OR_2_BOOL_IN" Type="iec61131::booleanOperators::OR_2_BOOL" x="1500" y="1500">
 		</FB>
-		<FB Name="OR_3_BOOL" Type="iec61131::bitwiseOperators::OR_3_BOOL" x="4000" y="800">
+		<FB Name="OR_3_BOOL" Type="iec61131::booleanOperators::OR_3_BOOL" x="4000" y="800">
 		</FB>
 		<EventConnections>
 			<Connection Source="REQ" Destination="OR_3_BOOL.REQ" dx1="1113.33"/>
 			<Connection Source="FB_SR.CNF" Destination="CNF" dx1="1113.33"/>
-			<Connection Source="OR_2_BOOL_IN.CNF" Destination="ILOCK_IN.EI1"/>
-			<Connection Source="OR_2_BOOL_OUT.CNF" Destination="ILOCK_OUT.EO1"/>
+			<Connection Source="OR_2_BOOL_IN.CNF" Destination="ILOCK_IN.EI1" dx1="253.33"/>
+			<Connection Source="OR_2_BOOL_OUT.CNF" Destination="ILOCK_OUT.EO1" dx1="200"/>
 			<Connection Source="ILOCK_IN.EO1" Destination="OR_3_BOOL.REQ" dx1="200"/>
 			<Connection Source="OR_3_BOOL.CNF" Destination="FB_SR.REQ" dx1="126.67"/>
 			<Connection Source="ILOCK_OUT.EI1" Destination="OR_3_BOOL.REQ" dx1="300"/>
-			<Connection Source="ILOCK_OUT.EI1" Destination="OR_2_BOOL_IN.REQ" dx1="300" dx2="100" dy="-346.67"/>
-			<Connection Source="ILOCK_IN.EO1" Destination="OR_2_BOOL_OUT.REQ" dx1="100" dx2="166.67" dy="586.67"/>
+			<Connection Source="ILOCK_OUT.EI1" Destination="OR_2_BOOL_IN.REQ" dx1="300" dx2="300" dy="-346.67"/>
+			<Connection Source="ILOCK_IN.EO1" Destination="OR_2_BOOL_OUT.REQ" dx1="100" dx2="100" dy="586.67"/>
 			<Connection Source="REQ" Destination="OR_2_BOOL_IN.REQ" dx1="1113.33"/>
 			<Connection Source="REQ" Destination="OR_2_BOOL_OUT.REQ" dx1="1113.33"/>
 		</EventConnections>
@@ -66,7 +66,7 @@
 			<Connection Source="ILOCK_IN.DO1" Destination="OR_3_BOOL.IN2" dx1="133.33"/>
 			<Connection Source="ILOCK_OUT.DI1" Destination="OR_3_BOOL.IN3" dx1="266.67"/>
 			<Connection Source="ILOCK_IN.DO1" Destination="OR_2_BOOL_OUT.IN1" dx1="66.67" dx2="66.67" dy="406.67"/>
-			<Connection Source="ILOCK_OUT.DI1" Destination="OR_2_BOOL_IN.IN2" dx1="266.67" dx2="66.67" dy="-593.33"/>
+			<Connection Source="ILOCK_OUT.DI1" Destination="OR_2_BOOL_IN.IN2" dx1="266.67" dx2="266.67" dy="-593.33"/>
 			<Connection Source="S1" Destination="OR_2_BOOL_IN.IN1" dx1="1146.67"/>
 			<Connection Source="S1" Destination="OR_2_BOOL_OUT.IN2" dx1="1146.67"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Type Library/MyLib/sys/AND_ZU.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Type Library/MyLib/sys/AND_ZU.SUB
@@ -26,7 +26,7 @@
 	<SubAppNetwork>
 		<FB Name="AND_3" Type="iec61131::bitwiseOperators::AND_2" x="2100" y="-100">
 		</FB>
-		<FB Name="F_NOT" Type="iec61131::bitwiseOperators::F_NOT_BOOL_INIT" x="0" y="-100">
+		<FB Name="F_NOT" Type="iec61131::booleanOperators::F_NOT_BOOL_INIT" x="0" y="-100">
 		</FB>
 		<EventConnections>
 			<Connection Source="AND_3.CNF" Destination="CNF" dx1="2400">
@@ -47,7 +47,7 @@
 			<Connection Source="IN2" Destination="F_NOT.IN" dx1="1126.67">
 				<Attribute Name="Visible" Value="false"/>
 			</Connection>
-			<Connection Source="F_NOT.OUT" Destination="AND_3.IN2"/>
+			<Connection Source="F_NOT.OUT" Destination="AND_3.IN2" dx1="613.33"/>
 		</DataConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_028c3_AR.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Uebungen/Uebung_028c3_AR.SUB
@@ -81,7 +81,7 @@
 		<FB Name="AR_REAL_TO_R_1" Type="adapter::conversion::unidirectional::AR_REAL_TO_R" x="4100" y="800">
 			<Parameter Name="OUT" Value="15.3"/>
 		</FB>
-		<FB Name="INIT" Type="iec61131::bitwiseOperators::INIT" x="3000" y="400">
+		<FB Name="INIT" Type="iec61131::booleanOperators::INIT" x="3000" y="400">
 		</FB>
 		<EventConnections>
 			<Connection Source="INIT.INITO" Destination="AR_REAL_TO_R.REQ" dx1="266.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Type Library/MyLib/sys/AND_ZU.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Type Library/MyLib/sys/AND_ZU.SUB
@@ -26,7 +26,7 @@
 	<SubAppNetwork>
 		<FB Name="AND_3" Type="iec61131::bitwiseOperators::AND_2" x="2100" y="-100">
 		</FB>
-		<FB Name="F_NOT" Type="iec61131::bitwiseOperators::F_NOT_BOOL_INIT" x="0" y="-100">
+		<FB Name="F_NOT" Type="iec61131::booleanOperators::F_NOT_BOOL_INIT" x="0" y="-100">
 		</FB>
 		<EventConnections>
 			<Connection Source="AND_3.CNF" Destination="CNF" dx1="2400">
@@ -47,7 +47,7 @@
 			<Connection Source="IN2" Destination="F_NOT.IN" dx1="1126.67">
 				<Attribute Name="Visible" Value="false"/>
 			</Connection>
-			<Connection Source="F_NOT.OUT" Destination="AND_3.IN2"/>
+			<Connection Source="F_NOT.OUT" Destination="AND_3.IN2" dx1="613.33"/>
 		</DataConnections>
 	</SubAppNetwork>
 </SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c2.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c2.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="F_NOT_BOOL" Type="iec61131::bitwiseOperators::F_NOT_BOOL" x="-1600" y="-700">
+		<FB Name="F_NOT_BOOL" Type="iec61131::booleanOperators::F_NOT_BOOL" x="-1600" y="-700">
 		</FB>
 		<Comment Comment="ohne die Linie INITO-&gt;REQ ist der Ausgang Q1 beim Start FALSE. mit der Linie ist er TRUE. &#10;" x="-4800" y="100" width="2200" height="500"/>
 		<EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c3.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c3.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="F_NOT_BOOL" Type="iec61131::bitwiseOperators::F_NOT_BOOL" x="-1600" y="-700">
+		<FB Name="F_NOT_BOOL" Type="iec61131::booleanOperators::F_NOT_BOOL" x="-1600" y="-700">
 		</FB>
 		<Comment Comment="ohne die Linie INITO-&gt;REQ ist der Ausgang Q1 beim Start FALSE. mit der Linie ist er TRUE. &#10;" x="-4800" y="100" width="2200" height="500"/>
 		<Comment Comment="&quot;Negate Connection&quot; mach ein NOT am Eingang; das geht nur bei BOOL. --&gt; hier wird aus dem F_NOT_BOOL dann ein NOOP. " x="-2000" y="0" width="1500" height="500"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c4.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001c4.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="NOOP" Type="iec61131::bitwiseOperators::NOOP" x="-1600" y="-700">
+		<FB Name="NOOP" Type="iec61131::booleanOperators::NOOP" x="-1600" y="-700">
 		</FB>
 		<Comment Comment="ohne die Linie INITO-&gt;REQ ist der Ausgang Q1 beim Start FALSE. mit der Linie ist er TRUE. &#10;" x="-4800" y="100" width="2200" height="500"/>
 		<Comment Comment="der NOOP Baustein kann auch verwendet werden um ein Gegenstück zu E_TRIG zu haben!&#10;" x="-1900" y="100" width="1500" height="400"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001d.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001d.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="AND_2_BOOL" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="-1400" y="-600">
+		<FB Name="AND_2_BOOL" Type="iec61131::booleanOperators::AND_2_BOOL" x="-1400" y="-600">
 		</FB>
 		<EventConnections>
 			<Connection Source="AND_2_BOOL.CNF" Destination="DigitalOutput_Q1.REQ" dx1="686.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001e.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001e.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="F_NOT_BOOL" Type="iec61131::bitwiseOperators::F_NOT_BOOL" x="-1600" y="-700">
+		<FB Name="F_NOT_BOOL" Type="iec61131::booleanOperators::F_NOT_BOOL" x="-1600" y="-700">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="F_NOT_BOOL.REQ" dx1="953.33"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001f.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_001f.SUB
@@ -19,7 +19,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I1"/>
 		</FB>
-		<FB Name="F_NOT_BOOL_INIT" Type="iec61131::bitwiseOperators::F_NOT_BOOL_INIT" x="-1600" y="-700">
+		<FB Name="F_NOT_BOOL_INIT" Type="iec61131::booleanOperators::F_NOT_BOOL_INIT" x="-1600" y="-700">
 		</FB>
 		<Comment Comment="obwohl I1 nicht abgefragt wird beim BOOT, wird AX_NOT hier TRUE ausgeben." x="-4600" y="200" width="2000" height="500"/>
 		<EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a4.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a4.SUB
@@ -24,12 +24,12 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I2"/>
 		</FB>
-		<FB Name="AND_2_BOOL" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="-2000" y="-400">
+		<FB Name="AND_2_BOOL" Type="iec61131::booleanOperators::AND_2_BOOL" x="-2000" y="-400">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="AND_2_BOOL.REQ" dx1="920"/>
 			<Connection Source="DigitalInput_I2.IND" Destination="AND_2_BOOL.REQ" dx1="920"/>
-			<Connection Source="AND_2_BOOL.CNF" Destination="DigitalOutput_Q1.REQ"/>
+			<Connection Source="AND_2_BOOL.CNF" Destination="DigitalOutput_Q1.REQ" dx1="333.33"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="AND_2_BOOL.OUT" Destination="DigitalOutput_Q1.OUT" dx1="206.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a4b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a4b.SUB
@@ -24,7 +24,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I2"/>
 		</FB>
-		<FB Name="AND_2_BOOL" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="-2000" y="-400">
+		<FB Name="AND_2_BOOL" Type="iec61131::booleanOperators::AND_2_BOOL" x="-2000" y="-400">
 		</FB>
 		<Comment Comment="&quot;Negate Connection&quot; mach ein NOT am Eingang; das geht nur bei BOOL." x="-2000" y="500" width="1500" height="500"/>
 		<EventConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a5b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002a5b.SUB
@@ -39,7 +39,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q3"/>
 		</FB>
-		<FB Name="OR_3_BOOL" Type="iec61131::bitwiseOperators::OR_3_BOOL" x="-2300" y="200">
+		<FB Name="OR_3_BOOL" Type="iec61131::booleanOperators::OR_3_BOOL" x="-2300" y="200">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="OR_3_BOOL.REQ" dx1="733.33"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002b3.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_002b3.SUB
@@ -25,13 +25,13 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I2"/>
 		</FB>
-		<FB Name="AND_2_BOOL" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="-2100" y="700">
+		<FB Name="AND_2_BOOL" Type="iec61131::booleanOperators::AND_2_BOOL" x="-2100" y="700">
 		</FB>
 		<FB Name="DigitalInput_I3" Type="logiBUS::io::DI::logiBUS_IX" x="-4500" y="1400">
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I3"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="100" y="1720">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="100" y="1720">
 		</FB>
 		<Comment Comment="kein F_MOVE mehr nötig. " x="-300" y="800" width="1300" height="200"/>
 		<EventConnections>
@@ -44,7 +44,7 @@
 		<DataConnections>
 			<Connection Source="DigitalInput_I1.IN" Destination="AND_2_BOOL.IN1" dx1="1160"/>
 			<Connection Source="DigitalInput_I2.IN" Destination="AND_2_BOOL.IN2"/>
-			<Connection Source="DigitalInput_I3.IN" Destination="OR_2_BOOL.IN2"/>
+			<Connection Source="DigitalInput_I3.IN" Destination="OR_2_BOOL.IN2" dx1="1920"/>
 			<Connection Source="OR_2_BOOL.OUT" Destination="DigitalOutput_Q1.OUT"/>
 			<Connection Source="AND_2_BOOL.OUT" Destination="OR_2_BOOL.IN1" dx1="680"/>
 		</DataConnections>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_006a3.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_006a3.SUB
@@ -47,7 +47,7 @@
 			<Parameter Name="Input" Value="Input_I3"/>
 			<Parameter Name="InputEvent" Value="BUTTON_SINGLE_CLICK"/>
 		</FB>
-		<FB Name="AND_LINKS" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="1300" y="-600">
+		<FB Name="AND_LINKS" Type="iec61131::booleanOperators::AND_2_BOOL" x="1300" y="-600">
 		</FB>
 		<FB Name="Rechtslauf" Type="logiBUS::io::DQ::logiBUS_QX" x="3200" y="400">
 			<Parameter Name="QI" Value="TRUE"/>
@@ -57,16 +57,16 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q1"/>
 		</FB>
-		<FB Name="AND_RECHTS" Type="iec61131::bitwiseOperators::AND_2_BOOL" x="1400" y="500">
+		<FB Name="AND_RECHTS" Type="iec61131::booleanOperators::AND_2_BOOL" x="1400" y="500">
 		</FB>
 		<SubApp Name="LinksRechts_T_FF" Type="Uebungen::Uebung_006a3_sub" x="-1300" y="-1400">
 		</SubApp>
 		<EventConnections>
-			<Connection Source="DigitalInput_CLK_I1.IND" Destination="E_T_FF_SR.S"/>
+			<Connection Source="DigitalInput_CLK_I1.IND" Destination="E_T_FF_SR.S" dx1="453.33"/>
 			<Connection Source="DigitalInput_CLK_I2.IND" Destination="E_T_FF_SR.R" dx1="486.67"/>
 			<Connection Source="DigitalInput_CLK_I3.IND" Destination="E_T_FF_SR.CLK" dx1="673.33"/>
-			<Connection Source="AND_RECHTS.CNF" Destination="Rechtslauf.REQ"/>
-			<Connection Source="AND_LINKS.CNF" Destination="Linkslauf.REQ"/>
+			<Connection Source="AND_RECHTS.CNF" Destination="Rechtslauf.REQ" dx1="580"/>
+			<Connection Source="AND_LINKS.CNF" Destination="Linkslauf.REQ" dx1="633.33"/>
 			<Connection Source="E_T_FF_SR.EO" Destination="LinksRechts_T_FF.EI" dx1="246.67"/>
 			<Connection Source="LinksRechts_T_FF.EO" Destination="AND_LINKS.REQ" dx1="1246.67"/>
 			<Connection Source="LinksRechts_T_FF.EO" Destination="AND_RECHTS.REQ" dx1="1146.67"/>
@@ -77,7 +77,7 @@
 			<Connection Source="AND_LINKS.OUT" Destination="Linkslauf.OUT" dx1="573.33"/>
 			<Connection Source="E_T_FF_SR.Q" Destination="AND_RECHTS.IN2" dx1="1313.33"/>
 			<Connection Source="AND_RECHTS.OUT" Destination="Rechtslauf.OUT" dx1="573.33"/>
-			<Connection Source="E_T_FF_SR.Q" Destination="AND_LINKS.IN2"/>
+			<Connection Source="E_T_FF_SR.Q" Destination="AND_LINKS.IN2" dx1="1693.33"/>
 			<Connection Source="LinksRechts_T_FF.Rechts" Destination="AND_RECHTS.IN1" dx1="1020"/>
 			<Connection Source="E_T_FF_SR.Q" Destination="LinksRechts_T_FF.DI" dx1="346.67"/>
 			<Connection Source="LinksRechts_T_FF.Links" Destination="AND_LINKS.IN1" dx1="886.67"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160.SUB
@@ -22,7 +22,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Input" Value="Input_I2"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-7800" y="700">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="-7800" y="700">
 		</FB>
 		<FB Name="DigitalInput_I1" Type="logiBUS::io::DI::logiBUS_IX" x="-9300" y="-800">
 			<Parameter Name="QI" Value="TRUE"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160b.SUB
@@ -23,7 +23,7 @@
 		</FB>
 		<FB Name="E_SR_Linkslauf" Type="iec61499::events::E_SR" x="-9300" y="1400">
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-7800" y="700">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="-7800" y="700">
 		</FB>
 		<FB Name="E_SR_Rechtslauf" Type="iec61499::events::E_SR" x="-9300" y="-800">
 		</FB>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160b2.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_160b2.SUB
@@ -21,7 +21,7 @@
 		</FB>
 		<FB Name="FB_RS_B" Type="iec61131::bistableElements::FB_RS" x="-9300" y="1400">
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="-7800" y="700">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="-7800" y="700">
 		</FB>
 		<FB Name="FB_RS_A" Type="iec61131::bistableElements::FB_RS" x="-9300" y="-800">
 		</FB>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_201b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_201b.SUB
@@ -36,7 +36,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q56"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="400" y="100">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="400" y="100">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="ILOCK.EI_UP" dx1="200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_202b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_202b.SUB
@@ -37,7 +37,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q56"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="800" y="100">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="800" y="100">
 		</FB>
 		<FB Name="E_TimeOut" Type="iec61499::events::E_TimeOut" x="200" y="1800">
 		</FB>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_203b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_203b.SUB
@@ -36,7 +36,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q56"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="400" y="100">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="400" y="100">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="ILOCK.EI_UP" dx1="200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_204b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_204b.SUB
@@ -46,7 +46,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q56"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="400" y="1200">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="400" y="1200">
 		</FB>
 		<EventConnections>
 			<Connection Source="DigitalInput_I1.IND" Destination="ILOCK.EI_UP" dx1="200"/>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_205b.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_205b.SUB
@@ -37,7 +37,7 @@
 			<Parameter Name="QI" Value="TRUE"/>
 			<Parameter Name="Output" Value="Output_Q56"/>
 		</FB>
-		<FB Name="OR_2_BOOL" Type="iec61131::bitwiseOperators::OR_2_BOOL" x="900" y="100">
+		<FB Name="OR_2_BOOL" Type="iec61131::booleanOperators::OR_2_BOOL" x="900" y="100">
 		</FB>
 		<FB Name="E_TimeOut" Type="iec61499::events::E_TimeOut" x="700" y="1900">
 		</FB>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/test_B.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/test_B.sys
@@ -8,7 +8,7 @@
 	</CompilerInfo>
 	<Application Name="App_B" Comment="Default App for Everything">
 		<SubAppNetwork>
-			<SubApp Name="Control" Type="Uebungen::Uebung_230" x="3100" y="0">
+			<SubApp Name="Control" Type="Uebungen::Uebung_002a4b" x="3100" y="0">
 			</SubApp>
 		</SubAppNetwork>
 	</Application>


### PR DESCRIPTION
Updated CompilerInfo from "bitwiseOperators" to "booleanOperators" and renamed GenericClassName attributes for boolean function blocks for improved clarity and consistency.

## Summary by Sourcery

Align naming and metadata for IEC 61131-3 boolean operator function blocks.

Enhancements:
- Rename the boolean operator function block package/metadata from bitwise-oriented naming to booleanOperators for consistency and clarity across the library.
- Update system configuration references to use the new booleanOperators naming for the affected boolean function blocks.