### PR TITLE
fix: update deployment paths and attributes for training systems

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/Launches/Deploy_App_AX.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/Launches/Deploy_App_AX.launch
@@ -14,5 +14,6 @@
         <setEntry value="FORTE_PC_AX"/>
         <setEntry value="FORTE_PC_AX.EMB_RES_AX"/>
     </setAttribute>
-    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_AX/test_AX.sys"/>
+    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_AX/sys/Training_AX/test_AX.sys"/>
+    <mapAttribute key="org.eclipse.fordiac.ide.deployment.debug.values"/>
 </launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_AX/sys/Training_AX/test_AX.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_AX/sys/Training_AX/test_AX.sys
@@ -13,7 +13,7 @@
 		</SubAppNetwork>
 	</Application>
 	<Device Name="FORTE_PC_AX" Type="iec61499::system::FORTE_PC" x="3126.67" y="1113.33">
-		<Parameter Name="MGR_ID" Value="&quot;192.168.178.127:61499&quot;" Comment="Device manager socket ID"/>
+		<Parameter Name="MGR_ID" Value="logiBUS::stations::Computers::C_00" Comment="Device manager socket ID"/>
 		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
 		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 		<Resource Name="EMB_RES_AX" Type="iec61499::system::EMB_RES" x="0" y="0">

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Launches/Deploy_App_B.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Launches/Deploy_App_B.launch
@@ -14,5 +14,6 @@
         <setEntry value="FORTE_PC_B"/>
         <setEntry value="FORTE_PC_B.EMB_RES_B"/>
     </setAttribute>
-    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_B/test_B.sys"/>
+    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_B/sys/Training_B/test_B.sys"/>
+    <mapAttribute key="org.eclipse.fordiac.ide.deployment.debug.values"/>
 </launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/sys/Training_B/test_B.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/sys/Training_B/test_B.sys
@@ -14,6 +14,8 @@
 	</Application>
 	<Device Name="FORTE_PC_B" Type="iec61499::system::FORTE_PC" x="3126.67" y="1113.33">
 		<Parameter Name="MGR_ID" Value="logiBUS::stations::Computers::C_00" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 		<Resource Name="EMB_RES_B" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="E_TRIG" Type="iec61499::events::E_TRIG" x="2300" y="800">
@@ -24,13 +26,11 @@
 				</EventConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 	</Device>
-	<Mapping From="App_B.Control" To="FORTE_PC_B.EMB_RES_B"/>
 	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="3600" y="480" dx1="2000">
 		<Attribute Name="Color" Type="STRING" Value="92,239,150"/>
 	</Segment>
+	<Mapping From="App_B.Control" To="FORTE_PC_B.EMB_RES_B"/>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_B" Comment="">
 	</Link>
 </System>

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_CLIENT_SERVER.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_CLIENT_SERVER.launch
@@ -16,5 +16,6 @@
         <setEntry value="FORTE_PC_SERVER"/>
         <setEntry value="FORTE_PC_SERVER.EMB_RES_SERVER"/>
     </setAttribute>
-    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/test_CLIENT_SERVER.sys"/>
+    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/sys/Training_CLIENT_SERVER/test_CLIENT_SERVER.sys"/>
+    <mapAttribute key="org.eclipse.fordiac.ide.deployment.debug.values"/>
 </launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_CLIENT_SERVER2.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_CLIENT_SERVER2.launch
@@ -16,5 +16,6 @@
         <setEntry value="FORTE_PC_SERVER"/>
         <setEntry value="FORTE_PC_SERVER.EMB_RES_SERVER"/>
     </setAttribute>
-    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/test_CLIENT_SERVER2.sys"/>
+    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/sys/Training_CLIENT_SERVER2/test_CLIENT_SERVER2.sys"/>
+    <mapAttribute key="org.eclipse.fordiac.ide.deployment.debug.values"/>
 </launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_PUBLISH_SUBSCRIBE.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Deploy_App_PUBLISH_SUBSCRIBE.launch
@@ -16,5 +16,6 @@
         <setEntry value="FORTE_PC_SUBSCRIBE"/>
         <setEntry value="FORTE_PC_SUBSCRIBE.EMB_RES_SUBSCRIBE"/>
     </setAttribute>
-    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/test_PUBLISH_SUBSCRIBE.sys"/>
+    <stringAttribute key="org.eclipse.fordiac.ide.deployment.debug.system" value="/test_VV/sys/Training_PUBLISH_SUBSCRIBE/test_PUBLISH_SUBSCRIBE.sys"/>
+    <mapAttribute key="org.eclipse.fordiac.ide.deployment.debug.values"/>
 </launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Launch_Deploy_App_CLIENT_SERVER2.launch
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/Launches/Launch_Deploy_App_CLIENT_SERVER2.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.debug.core.groups.GroupLaunchConfigurationType">
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.action" value="NONE"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.adoptIfRunning" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.enabled" value="true"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.mode" value="inherit"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.name" value="Deploy_App_CLIENT_SERVER2"/>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+        <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+    </listAttribute>
+</launchConfiguration>

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_CLIENT_SERVER/test_CLIENT_SERVER.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_CLIENT_SERVER/test_CLIENT_SERVER.sys
@@ -84,6 +84,8 @@
 	</Application>
 	<Device Name="FORTE_PC_CLIENT" Type="iec61499::system::FORTE_PC" x="2160" y="2080">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_SERVER" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 		<Resource Name="EMB_RES_CLIENT" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="CLIENT_BUTTON_GREEN" Type="iec61499::net::CLIENT_1" x="4400" y="400">
@@ -140,11 +142,11 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 	</Device>
 	<Device Name="FORTE_PC_SERVER" Type="iec61499::system::FORTE_PC" x="3200" y="2880">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_CLIENT" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 		<Resource Name="EMB_RES_SERVER" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="SERVER_BUTTON_GREEN" Type="iec61499::net::SERVER_1" x="2700" y="700">
@@ -189,9 +191,10 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 	</Device>
+	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2940" y="1486.67" dx1="2000">
+		<Attribute Name="Color" Type="STRING" Value="176,74,223"/>
+	</Segment>
 	<Mapping From="App_CLIENT_SERVER.BUTTON_BLUE" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
 	<Mapping From="App_CLIENT_SERVER.BUTTON_RED" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
 	<Mapping From="App_CLIENT_SERVER.BUTTON_YELLOW" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
@@ -204,9 +207,6 @@
 	<Mapping From="App_CLIENT_SERVER.E_CTU_LED_RED_5HZ" To="FORTE_PC_SERVER.EMB_RES_SERVER"/>
 	<Mapping From="App_CLIENT_SERVER.E_CTU_LED_GREEN_5HZ" To="FORTE_PC_SERVER.EMB_RES_SERVER"/>
 	<Mapping From="App_CLIENT_SERVER.E_CTU_LED_BLUE_5HZ" To="FORTE_PC_SERVER.EMB_RES_SERVER"/>
-	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2940" y="1486.67" dx1="2000">
-		<Attribute Name="Color" Type="STRING" Value="176,74,223"/>
-	</Segment>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_CLIENT" Comment="">
 	</Link>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_SERVER" Comment="">

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_CLIENT_SERVER2/test_CLIENT_SERVER2.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_CLIENT_SERVER2/test_CLIENT_SERVER2.sys
@@ -2,7 +2,7 @@
 <System Name="test_CLIENT_SERVER2">
 	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23">
 	</VersionInfo>
-	<CompilerInfo packageName="Training_CLIENT_SERVER">
+	<CompilerInfo packageName="Training_CLIENT_SERVER2">
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q1"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q2"/>
 		<Import declaration="logiBUS::io::DQ::logiBUS_DO::Output_Q3"/>
@@ -58,6 +58,8 @@
 	</Application>
 	<Device Name="FORTE_PC_CLIENT" Type="iec61499::system::FORTE_PC" x="1760" y="1760">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_CLIENT" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 		<Resource Name="EMB_RES_CLIENT" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="CLIENT_BUTTON_GREEN" Type="iec61499::net::CLIENT_1" x="4400" y="900">
@@ -114,11 +116,11 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 	</Device>
 	<Device Name="FORTE_PC_SERVER" Type="iec61499::system::FORTE_PC" x="2560" y="2560">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_SERVER" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 		<Resource Name="EMB_RES_SERVER" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="SERVER_BUTTON_GREEN" Type="iec61499::net::SERVER_1" x="2700" y="700">
@@ -159,9 +161,10 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 	</Device>
+	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2640" y="1360" dx1="2000">
+		<Attribute Name="Color" Type="STRING" Value="242,128,114"/>
+	</Segment>
 	<Mapping From="App_CLIENT_SERVER.Input_I4" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
 	<Mapping From="App_CLIENT_SERVER.Input_I3" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
 	<Mapping From="App_CLIENT_SERVER.Input_I2" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
@@ -170,9 +173,6 @@
 	<Mapping From="App_CLIENT_SERVER.Output_Q4" To="FORTE_PC_SERVER.EMB_RES_SERVER"/>
 	<Mapping From="App_CLIENT_SERVER.Output_Q1" To="FORTE_PC_SERVER.EMB_RES_SERVER"/>
 	<Mapping From="App_CLIENT_SERVER.Input_I1" To="FORTE_PC_CLIENT.EMB_RES_CLIENT"/>
-	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2640" y="1360" dx1="2000">
-		<Attribute Name="Color" Type="STRING" Value="242,128,114"/>
-	</Segment>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_CLIENT" Comment="">
 	</Link>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_SERVER" Comment="">

--- a/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_PUBLISH_SUBSCRIBE/test_PUBLISH_SUBSCRIBE.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_VV/sys/Training_PUBLISH_SUBSCRIBE/test_PUBLISH_SUBSCRIBE.sys
@@ -72,6 +72,8 @@
 	</Application>
 	<Device Name="FORTE_PC_PUBLISH" Type="iec61499::system::FORTE_PC" x="1760" y="1840">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_PUBLISH" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 		<Resource Name="EMB_RES_PUBLISH" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="PUBLISH_BUTTON_GREEN" Type="iec61499::net::PUBLISH_1" x="4400" y="700">
@@ -108,11 +110,11 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="255,190,111"/>
 	</Device>
 	<Device Name="FORTE_PC_SUBSCRIBE" Type="iec61499::system::FORTE_PC" x="2400" y="2560">
 		<Parameter Name="MGR_ID" Value="VV::const::Computers::myComputers::C_PC_SUBSCRIBE" Comment="Device manager socket ID"/>
+		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
+		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 		<Resource Name="EMB_RES_SUBSCRIBE" Type="iec61499::system::EMB_RES" x="0" y="0">
 			<FBNetwork>
 				<FB Name="SUBSCRIBE_BUTTON_GREEN" Type="iec61499::net::SUBSCRIBE_1" x="2800" y="700">
@@ -149,9 +151,10 @@
 				</DataConnections>
 			</FBNetwork>
 		</Resource>
-		<Attribute Name="Profile" Type="STRING" Value="HOLOBLOC"/>
-		<Attribute Name="Color" Type="STRING" Value="59,215,47"/>
 	</Device>
+	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2640" y="1440" dx1="2000">
+		<Attribute Name="Color" Type="STRING" Value="56,90,235"/>
+	</Segment>
 	<Mapping From="App_PUBLISH_SUBSCRIBE.BUTTON_BLUE" To="FORTE_PC_PUBLISH.EMB_RES_PUBLISH"/>
 	<Mapping From="App_PUBLISH_SUBSCRIBE.BUTTON_RED" To="FORTE_PC_PUBLISH.EMB_RES_PUBLISH"/>
 	<Mapping From="App_PUBLISH_SUBSCRIBE.BUTTON_YELLOW" To="FORTE_PC_PUBLISH.EMB_RES_PUBLISH"/>
@@ -160,9 +163,6 @@
 	<Mapping From="App_PUBLISH_SUBSCRIBE.LED_BLUE_5HZ" To="FORTE_PC_SUBSCRIBE.EMB_RES_SUBSCRIBE"/>
 	<Mapping From="App_PUBLISH_SUBSCRIBE.LED_GREEN_5HZ" To="FORTE_PC_SUBSCRIBE.EMB_RES_SUBSCRIBE"/>
 	<Mapping From="App_PUBLISH_SUBSCRIBE.BUTTON_GREEN" To="FORTE_PC_PUBLISH.EMB_RES_PUBLISH"/>
-	<Segment Name="Ethernet" Type="iec61499::system::Ethernet" x="2640" y="1440" dx1="2000">
-		<Attribute Name="Color" Type="STRING" Value="56,90,235"/>
-	</Segment>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_PUBLISH" Comment="">
 	</Link>
 	<Link SegmentName="Ethernet" CommResource="FORTE_PC_SUBSCRIBE" Comment="">


### PR DESCRIPTION
Refactor directory structure to include a 'Training' prefix for system files. This change ensures consistent organization for training-related assets, improving clarity and maintainability. Also, modify device manager socket IDs and organize Ethernet segments to optimize configuration management.

## Summary by Sourcery

Organize 4diac training system configurations under dedicated Training_* subdirectories and align deployment launch configurations with the new structure.

New Features:
- Add a dedicated launch configuration for deploying the CLIENT_SERVER2 training application.

Enhancements:
- Restructure system file locations for AX, B, and VV tests into Training_* subfolders to clearly separate training setups from other configurations.