### PR TITLE
feat: integrate Uebung_010a5 for SoftKey_F1-to-DigitalOutput_Q1 mapping

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules_with_medium_IO_density/DQ/DataPanel_MI_DO.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/DataPanel-3.0.0/typelib/io/Modules_with_medium_IO_density/DQ/DataPanel_MI_DO.gcf
@@ -23,10 +23,14 @@
 		<VarDeclaration Name="DigitalOutput_7B" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 14)"/>
 		<VarDeclaration Name="DigitalOutput_8A" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 15)"/>
 		<VarDeclaration Name="DigitalOutput_8B" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 16)"/>
-		<VarDeclaration Name="Input_Power_Port_5" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 17)"/>
-		<VarDeclaration Name="Input_Power_Port_6" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 18)"/>
-		<VarDeclaration Name="Input_Power_Port_7" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 19)"/>
-		<VarDeclaration Name="Input_Power_Port_8" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 20)"/>
+		<VarDeclaration Name="Input_Power_Port_1" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 17)"/>
+		<VarDeclaration Name="Input_Power_Port_2" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 18)"/>
+		<VarDeclaration Name="Input_Power_Port_3" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 19)"/>
+		<VarDeclaration Name="Input_Power_Port_4" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 20)"/>
+		<VarDeclaration Name="Input_Power_Port_5" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 21)"/>
+		<VarDeclaration Name="Input_Power_Port_6" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 22)"/>
+		<VarDeclaration Name="Input_Power_Port_7" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 23)"/>
+		<VarDeclaration Name="Input_Power_Port_8" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 24)"/>
 		<VarDeclaration Name="Invalid" Type="DataPanel::io::MI::DQ::DataPanel_MI_DO_S" InitialValue="(Pin := 255)"/>
 	</GlobalConstants>
 	<OriginalSource><![CDATA[PACKAGE DataPanel::io::MI::DQ;
@@ -49,10 +53,14 @@ GLOBALCONSTANTS DataPanel_MI_DO
 		DigitalOutput_7B : DataPanel_MI_DO_S := (Pin := 14);
 		DigitalOutput_8A : DataPanel_MI_DO_S := (Pin := 15);
 		DigitalOutput_8B : DataPanel_MI_DO_S := (Pin := 16);
-		Input_Power_Port_5 : DataPanel_MI_DO_S := (Pin := 17);
-		Input_Power_Port_6 : DataPanel_MI_DO_S := (Pin := 18);
-		Input_Power_Port_7 : DataPanel_MI_DO_S := (Pin := 19);
-		Input_Power_Port_8 : DataPanel_MI_DO_S := (Pin := 20);
+		Input_Power_Port_1 : DataPanel_MI_DO_S := (Pin := 17);
+		Input_Power_Port_2 : DataPanel_MI_DO_S := (Pin := 18);
+		Input_Power_Port_3 : DataPanel_MI_DO_S := (Pin := 19);
+		Input_Power_Port_4 : DataPanel_MI_DO_S := (Pin := 20);
+		Input_Power_Port_5 : DataPanel_MI_DO_S := (Pin := 21);
+		Input_Power_Port_6 : DataPanel_MI_DO_S := (Pin := 22);
+		Input_Power_Port_7 : DataPanel_MI_DO_S := (Pin := 23);
+		Input_Power_Port_8 : DataPanel_MI_DO_S := (Pin := 24);
 		Invalid : DataPanel_MI_DO_S := (Pin := 255);
 	END_VAR
 END_GLOBALCONSTANTS

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_010a5.SUB
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/Uebungen/Uebung_010a5.SUB
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SubAppType Name="Uebung_010a5" Comment="SoftKey_F1 auf DigitalOutput_Q1 (Datapanel)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2023 Meisterschulen am Ostbahnhof  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="Meisterschulen am Ostbahnhof" Version="1.0" Author="Franz Höpfinger" Date="2023-10-23" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="Uebungen">
+		<Import declaration="DataPanel::io::MI::DQ::DataPanel_MI_DO::Input_Power_Port_5"/>
+		<Import declaration="DataPanel::io::MI::const::MI::MI_00"/>
+		<Import declaration="Uebungen::const::UT::DefaultPool::SoftKey_F1"/>
+	</CompilerInfo>
+	<SubAppInterfaceList>
+	</SubAppInterfaceList>
+	<SubAppNetwork>
+		<FB Name="Input_Power_Port_5" Type="DataPanel::io::MI::DQ::DataPanel_MI_QX" x="-1400" y="-300">
+			<Parameter Name="QI" Value="TRUE"/>
+			<Parameter Name="u8SAMember" Value="MI_00"/>
+			<Parameter Name="Output" Value="Input_Power_Port_5"/>
+		</FB>
+		<FB Name="SoftKey_F1" Type="isobus::UT::io::Softkey::Softkey_IX" x="-4600" y="-500">
+			<Parameter Name="QI" Value="TRUE"/>
+			<Parameter Name="u16ObjId" Value="SoftKey_F1"/>
+		</FB>
+		<EventConnections>
+			<Connection Source="SoftKey_F1.IND" Destination="Input_Power_Port_5.REQ" dx1="1206.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="SoftKey_F1.IN" Destination="Input_Power_Port_5.OUT" dx1="1206.67"/>
+		</DataConnections>
+	</SubAppNetwork>
+</SubAppType>

--- a/Ventilsteuerung/4diacIDE-workspace/test_B/sys/Training_B/test_B.sys
+++ b/Ventilsteuerung/4diacIDE-workspace/test_B/sys/Training_B/test_B.sys
@@ -8,7 +8,7 @@
 	</CompilerInfo>
 	<Application Name="App_B" Comment="Default App for Everything">
 		<SubAppNetwork>
-			<SubApp Name="Control" Type="Uebungen::Uebung_002a4b" x="3100" y="0">
+			<SubApp Name="Control" Type="Uebungen::Uebung_010a5" x="3100" y="0">
 			</SubApp>
 		</SubAppNetwork>
 	</Application>


### PR DESCRIPTION
Introduce new SubAppType Uebung_010a5 to map SoftKey_F1 to DigitalOutput_Q1 on the DataPanel. Updated the default application in test_B.sys to use this new SubApp, enhancing button interaction over the DataPanel interface.

## Summary by Sourcery

Add a new training subapplication and update the test_B system configuration to map a DataPanel soft key to a digital output.

New Features:
- Introduce SubApp Uebung_010a5 to map SoftKey_F1 on the DataPanel to DigitalOutput_Q1 in the training setup.
- Update the default Training_B/test_B.sys configuration to use the new Uebung_010a5 subapplication for DataPanel interaction.

Enhancements:
- Adjust DataPanel_MI_DO I/O configuration to support the new soft key to digital output mapping in the training environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for eight input power ports with updated pin assignments.
  * Added a new training subapplication integrating input power control with the F1 soft key.
  * Updated the training system to use the new subapplication.

* **Bug Fixes**
  * Corrected input power port mappings to reflect the expanded hardware configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->