### PR TITLE
Add ERR_READ_ONLY status and document read-only settings overlay in INI FB

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/const/storageStatusMessages.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/const/storageStatusMessages.gcf
@@ -2,6 +2,8 @@
 <GlobalConstants Name="storageStatusMessages" Comment="Global constants for storage status messages (INI and NVS)">
 	<Identification Standard="61499-1">
 	</Identification>
+	<VersionInfo Version="1.2" Author="franz" Date="2026-08-01" Remarks="added read-only settings error message">
+	</VersionInfo>
 	<VersionInfo Version="1.1" Author="franz" Date="2026-06-13">
 	</VersionInfo>
 	<CompilerInfo packageName="logiBUS::storage::const">
@@ -18,6 +20,7 @@
 		<VarDeclaration Name="ERR_KEY_EMPTY" Type="STRING" InitialValue="'KEY empty'"/>
 		<VarDeclaration Name="ERR_SECTION_WHITESPACE" Type="STRING" InitialValue="'SECTION contains whitespace'"/>
 		<VarDeclaration Name="ERR_KEY_WHITESPACE" Type="STRING" InitialValue="'KEY contains whitespace'"/>
+		<VarDeclaration Name="ERR_READ_ONLY" Type="STRING" InitialValue="'Key is read-only'"/>
 	</GlobalConstants>
 	<OriginalSource><![CDATA[PACKAGE logiBUS::storage::const;
 
@@ -34,6 +37,7 @@ GLOBALCONSTANTS storageStatusMessages
 		ERR_KEY_EMPTY : STRING := 'KEY empty';
 		ERR_SECTION_WHITESPACE : STRING := 'SECTION contains whitespace';
 		ERR_KEY_WHITESPACE : STRING := 'KEY contains whitespace';
+		ERR_READ_ONLY : STRING := 'Key is read-only';
 	END_VAR
 END_GLOBALCONSTANTS
 ]]></OriginalSource>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI.fbt
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="INI" Comment="Load and Store Data from settings.ini by Section and Key">
+<FBType Name="INI" Comment="Load and Store Data from settings.ini by Section and Key. Keys also present in the read-only settingsReadOnly.ini overlay cannot be modified via SET.">
 	<Identification Standard="61499-2" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.2" Author="Franz Höpfinger" Date="2026-08-01" Remarks="reject SET on read-only keys, SETO/SETOE now follow STATUS==OK">
+	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-12" Remarks="added Error Handling">
 	</VersionInfo>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/storage/ini/INI.fbt
@@ -2,7 +2,7 @@
 <FBType Name="INI" Comment="Load and Store Data from settings.ini by Section and Key. Keys also present in the read-only settingsReadOnly.ini overlay cannot be modified via SET.">
 	<Identification Standard="61499-2" Description="Copyright (c) 2024 HR Agrartechnik GmbH   &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0 ">
 	</Identification>
-	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.2" Author="Franz Höpfinger" Date="2026-08-01" Remarks="reject SET on read-only keys, SETO/SETOE now follow STATUS==OK">
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.2" Author="Franz Höpfinger" Date="2026-08-01" Remarks="read-only keys rejected by SET set STATUS to ERR_READ_ONLY, SETO is emitted when STATUS == OK, and SETOE otherwise">
 	</VersionInfo>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-06-12" Remarks="added Error Handling">
 	</VersionInfo>


### PR DESCRIPTION
Prepares the INI function block type for rejecting SET on keys that are
locked by the new settingsReadOnly.ini overlay in SettingsIni.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Introduce a read-only settings status to the storage system and prepare the INI function block for handling locked keys.

New Features:
- Add a new ERR_READ_ONLY storage status for operations on locked settings entries.

Enhancements:
- Update the INI function block type documentation to describe behavior with the settingsReadOnly.ini overlay and read-only keys.

Documentation:
- Document the interaction between INI SET operations and the settingsReadOnly.ini overlay in the INI function block definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear status message when attempting to modify a read-only setting.

* **Documentation**
  * Documented the read-only settings overlay and clarified that `SET` cannot change its keys.
  * Clarified `SETO` and `SETOE` behavior when the operation status is successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->