### PR TITLE
Add const_AX_TRUE/FALSE and initval_AX helper FBs

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_FALSE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_FALSE.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="const_AX_FALSE" Comment="a CONST FALSE for AX Interface">
-	<Identification Standard="61499-2">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
 	</VersionInfo>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_FALSE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_FALSE.fbt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="const_AX_FALSE" Comment="a CONST FALSE for AX Interface">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AX::constants">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="will output FALSE at INIT" x="66.67" y="66.67">
+				<Parameter Name="D1" Value="FALSE"/>
+			</AdapterDeclaration>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_TRUE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_TRUE.fbt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="const_AX_TRUE" Comment="a CONST TRUE for AX Interface">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AX::constants">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="will output TRUE at INIT" x="66.67" y="66.67">
+				<Parameter Name="D1" Value="TRUE"/>
+			</AdapterDeclaration>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_TRUE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/constants/const_AX_TRUE.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="const_AX_TRUE" Comment="a CONST TRUE for AX Interface">
-	<Identification Standard="61499-2">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
 	</VersionInfo>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/initval/initval_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/initval/initval_AX.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="initval_AX" Comment="a initval for AX Interface">
-	<Identification Standard="61499-2">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
 	</VersionInfo>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/initval/initval_AX.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BOOL/initval/initval_AX.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AX" Comment="a initval for AX Interface">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="franz" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AX::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="BOOL"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="will output FALSE at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>


### PR DESCRIPTION
Fixed AX-adapter constant/initial-value sources for wiring a safe
default into an unused AX_MUX socket, synced from Getreideannahme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add AX adapter-specific BOOL constant and initial-value function blocks for configuring safe default values on unused AX_MUX sockets.

New Features:
- Introduce const_AX_TRUE and const_AX_FALSE BOOL function blocks as AX adapter constant sources.
- Provide initval_AX BOOL function block for supplying initial values to AX adapter connections.