### PR TITLE
Add Override_K_Select as a standard adapter-3.0.0 building block

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/Override_K_Select.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/Override_K_Select.fbt
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="Override_K_Select" Comment="Aktiv/Wert (AX) zu K (AUI) fuer AX_AUI_MUX_3: 0=Normal, 1=Force FALSE, 2=Force TRUE">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::OverrideK">
+		<Import declaration="adapter::OverrideK::const::Override_K::Override_K_Normal"/>
+		<Import declaration="adapter::OverrideK::const::Override_K::Override_K_ForceFalse"/>
+		<Import declaration="adapter::OverrideK::const::Override_K::Override_K_ForceTrue"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="K" Type="adapter::types::unidirectional::AUI" Comment="0=Normal (Aktiv=FALSE), 1=Force FALSE (Aktiv=TRUE, Wert=FALSE), 2=Force TRUE (Aktiv=TRUE, Wert=TRUE)" x="5700" y="600"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="Aktiv" Type="adapter::types::unidirectional::AX" Comment="Override.Aktiv" x="-200" y="600"/>
+			<AdapterDeclaration Name="Wert" Type="adapter::types::unidirectional::AX" Comment="Override.Wert" x="-200" y="-200"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_SEL_Wert" Type="iec61131::selection::F_SEL" x="1300" y="-200">
+			<Parameter Name="IN0" Value="Override_K_ForceFalse"/>
+			<Parameter Name="IN1" Value="Override_K_ForceTrue"/>
+		</FB>
+		<FB Name="F_SEL_Aktiv" Type="iec61131::selection::F_SEL" x="4100" y="600">
+			<Parameter Name="IN0" Value="Override_K_Normal"/>
+		</FB>
+		<FB Name="F_MOVE" Type="iec61131::selection::F_MOVE" x="2500" y="-200">
+			<Attribute Name="DataType" Value="UINT"/>
+		</FB>
+		<EventConnections>
+			<Connection Source="Wert.E1" Destination="F_SEL_Wert.REQ"/>
+			<Connection Source="Aktiv.E1" Destination="F_SEL_Aktiv.REQ"/>
+			<Connection Source="F_SEL_Aktiv.CNF" Destination="K.E1"/>
+			<Connection Source="F_SEL_Wert.CNF" Destination="F_MOVE.REQ"/>
+			<Connection Source="F_MOVE.CNF" Destination="F_SEL_Aktiv.REQ" dx1="746.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="Wert.D1" Destination="F_SEL_Wert.G"/>
+			<Connection Source="Aktiv.D1" Destination="F_SEL_Aktiv.G"/>
+			<Connection Source="F_SEL_Wert.OUT" Destination="F_MOVE.IN"/>
+			<Connection Source="F_SEL_Aktiv.OUT" Destination="K.D1"/>
+			<Connection Source="F_MOVE.OUT" Destination="F_SEL_Aktiv.IN1" dx1="513.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/const/Override_K.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/const/Override_K.gcf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalConstants Name="Override_K" Comment="K-Werte fuer AX_AUI_MUX_3 in Override_K_Select (0=Normal, 1=Force FALSE, 2=Force TRUE)">
+	<Identification Standard="61499-1" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::OverrideK::const">
+	</CompilerInfo>
+	<GlobalConstants>
+		<VarDeclaration Name="Override_K_Normal" Type="UINT" Comment="K=0, AX_AUI_MUX_3.IN1 (Normal/Eingang)" InitialValue="UINT#0"/>
+		<VarDeclaration Name="Override_K_ForceFalse" Type="UINT" Comment="K=1, AX_AUI_MUX_3.IN2 (Force FALSE / Voll)" InitialValue="UINT#1"/>
+		<VarDeclaration Name="Override_K_ForceTrue" Type="UINT" Comment="K=2, AX_AUI_MUX_3.IN3 (Force TRUE / Leer)" InitialValue="UINT#2"/>
+	</GlobalConstants>
+	<OriginalSource><![CDATA[PACKAGE adapter::OverrideK::const;
+
+GLOBALCONSTANTS Override_K
+	VAR_GLOBAL CONSTANT
+		Override_K_Normal : UINT := 0;
+		Override_K_ForceFalse : UINT := 1;
+		Override_K_ForceTrue : UINT := 2;
+	END_VAR
+END_GLOBALCONSTANTS
+]]></OriginalSource>
+</GlobalConstants>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/const/Override_K.gcf
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/OverrideK/const/Override_K.gcf
@@ -21,4 +21,5 @@ GLOBALCONSTANTS Override_K
 	END_VAR
 END_GLOBALCONSTANTS
 ]]></OriginalSource>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
 </GlobalConstants>


### PR DESCRIPTION
Aktiv/Wert (AX) -> K (AUI) selector for AX_AUI_MUX_3-based overrides
(0=Normal, 1=Force FALSE, 2=Force TRUE), built from chained F_SEL
calls plus AUI_UINT_TO_UI. Synced from Getreideannahme, where it
started life app-specific under test/FBs before being promoted here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Introduce a reusable Override_K selector building block to the adapter-3.0.0 library.

New Features:
- Add Override_K_Select function block for AX-to-K override selection based on AX_AUI_MUX_3 semantics.
- Add corresponding Override_K constant configuration for use with the new selector block.