### PR TITLE
Add AX_ATM_FB_TON/TOF/TP: timers with PT and ET as ATM adapters

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TOF.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TOF.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AX_ATM_FB_TOF" Comment="standard timer function block (off-delay timing) with AX/ATM Adapter, PT and ET as adapters">
-	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TOF, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TOF, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.  &#10; &#10;PT-Verhalten: PT.D1 liegt als reine Datenverbindung dauerhaft am internen&#10;FB_TOF.PT an - der Adapter puffert/entprellt PT nicht. IN.E1, PT.E1 und das&#10;externe REQ sind gleichwertige Ausloeser fuer dieselbe FB_TOF.REQ-Auswertung.&#10;Eine Aenderung von PT ist also nicht am Abfallen von IN eingefroren, sondern&#10;wirkt bei der naechsten Auswertung sofort mit dem dann aktuellen ET zusammen -&#10;siehe Technische Besonderheiten in der Doku fuer die Grenzfaelle PT=0 und&#10;schnell aufeinanderfolgende PT-Aenderungen. Vor dem allerersten PT.E1 liegt an&#10;FB_TOF.PT der TIME-Standardwert T#0s an, nicht ein projektspezifischer Default.">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
 	</VersionInfo>
@@ -8,7 +8,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); gleichwertig zu IN.E1/PT.E1 (alle drei loesen dieselbe interne Neuauswertung aus). Anwendung haengt hier periodisch einen E_CYCLE an, damit ET auch ohne IN-/PT-Aenderung aktualisiert wird">
 			</Event>
 		</EventInputs>
 		<Plugs>
@@ -17,7 +17,7 @@
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="100" y="1100"/>
-			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time" x="100" y="1600"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time; live/nicht gelatched - PT.E1 loest wie IN.E1/REQ sofort eine Neuauswertung mit dem neuen PT-Wert aus, keine Entprellung. PT=0 laesst Q bei der naechsten Auswertung nach Abfallen von IN sofort FALSE werden" x="100" y="1600"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TOF.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TOF.fbt
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AX_ATM_FB_TOF" Comment="standard timer function block (off-delay timing) with AX/ATM Adapter, PT and ET as adapters">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TOF, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			</Event>
+		</EventInputs>
+		<Plugs>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2660" y="180"/>
+			<AdapterDeclaration Name="ET" Type="adapter::types::unidirectional::ATM" Comment="Elapsed time, Event nur bei Wertaenderung" x="2846.67" y="973.33"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="100" y="1100"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time" x="100" y="1600"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="FB_TOF" Type="iec61131::timers::FB_TOF" x="900" y="900">
+		</FB>
+		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="1780" y="180">
+		</FB>
+		<FB Name="E_D_FF_ANY" Type="iec61499::events::E_D_FF_ANY" x="1780" y="973.33">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="FB_TOF.REQ" dx1="93.33"/>
+			<Connection Source="REQ" Destination="FB_TOF.REQ" dx1="993.33"/>
+			<Connection Source="FB_TOF.CNF" Destination="E_D_FF.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF.EO" Destination="Q.E1"/>
+			<Connection Source="FB_TOF.CNF" Destination="E_D_FF_ANY.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.EO" Destination="ET.E1"/>
+			<Connection Source="PT.E1" Destination="FB_TOF.REQ" dx1="166.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="FB_TOF.IN" dx1="93.33"/>
+			<Connection Source="PT.D1" Destination="FB_TOF.PT" dx1="240"/>
+			<Connection Source="FB_TOF.Q" Destination="E_D_FF.D" dx1="133.33"/>
+			<Connection Source="E_D_FF.Q" Destination="Q.D1"/>
+			<Connection Source="FB_TOF.ET" Destination="E_D_FF_ANY.D" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.Q" Destination="ET.D1"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TON.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TON.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AX_ATM_FB_TON" Comment="standard timer function block (on-delay timing) with AX/ATM Adapter, PT and ET as adapters">
-	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TON, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, damit sie ueber AR_SUBSCRIBE_1/AR_PUBLISH_1-artige&#10;Ketten mit REAL-Sekundenwerten verdrahtet werden koennen, ohne eigene&#10;Datenverbindungen fuer PT/ET zu brauchen. REQ bleibt ein einfaches Event -&#10;damit die Anwendung selbst einen E_CYCLE anschliessen kann, um ET periodisch&#10;zu aktualisieren, waehrend der Timer laeuft. ET feuert sein Adapterereignis&#10;nur bei tatsaechlicher Wertaenderung (E_D_FF_ANY), nicht bei jedem REQ.">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TON, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, damit sie ueber AR_SUBSCRIBE_1/AR_PUBLISH_1-artige&#10;Ketten mit REAL-Sekundenwerten verdrahtet werden koennen, ohne eigene&#10;Datenverbindungen fuer PT/ET zu brauchen. REQ bleibt ein einfaches Event -&#10;damit die Anwendung selbst einen E_CYCLE anschliessen kann, um ET periodisch&#10;zu aktualisieren, waehrend der Timer laeuft. ET feuert sein Adapterereignis&#10;nur bei tatsaechlicher Wertaenderung (E_D_FF_ANY), nicht bei jedem REQ.  &#10; &#10;PT-Verhalten: PT.D1 liegt als reine Datenverbindung dauerhaft am internen&#10;FB_TON.PT an - der Adapter puffert/entprellt PT nicht. IN.E1, PT.E1 und das&#10;externe REQ sind gleichwertige Ausloeser fuer dieselbe FB_TON.REQ-Auswertung;&#10;FB_TON selbst unterscheidet nicht, welcher der drei es war. Eine Aenderung von&#10;PT ist also nicht am Start (steigende Flanke von IN) eingefroren, sondern wirkt&#10;bei der naechsten Auswertung sofort mit dem dann aktuellen ET zusammen - siehe&#10;Technische Besonderheiten in der Doku fuer die Grenzfaelle PT=0 und schnell&#10;aufeinanderfolgende PT-Aenderungen. Vor dem allerersten PT.E1 liegt an&#10;FB_TON.PT der TIME-Standardwert T#0s an, nicht ein projektspezifischer Default.">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
 	</VersionInfo>
@@ -8,7 +8,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); gleichwertig zu IN.E1/PT.E1 (alle drei loesen dieselbe interne Neuauswertung aus). Anwendung haengt hier periodisch einen E_CYCLE an, damit ET auch ohne IN-/PT-Aenderung aktualisiert wird">
 			</Event>
 		</EventInputs>
 		<Plugs>
@@ -17,7 +17,7 @@
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="300" y="800"/>
-			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time" x="300" y="1300"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time; live/nicht gelatched - PT.E1 loest wie IN.E1/REQ sofort eine Neuauswertung mit dem neuen PT-Wert aus, keine Entprellung. PT=0 laesst Q bei der naechsten Auswertung sofort TRUE werden" x="300" y="1300"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TON.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TON.fbt
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AX_ATM_FB_TON" Comment="standard timer function block (on-delay timing) with AX/ATM Adapter, PT and ET as adapters">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TON, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, damit sie ueber AR_SUBSCRIBE_1/AR_PUBLISH_1-artige&#10;Ketten mit REAL-Sekundenwerten verdrahtet werden koennen, ohne eigene&#10;Datenverbindungen fuer PT/ET zu brauchen. REQ bleibt ein einfaches Event -&#10;damit die Anwendung selbst einen E_CYCLE anschliessen kann, um ET periodisch&#10;zu aktualisieren, waehrend der Timer laeuft. ET feuert sein Adapterereignis&#10;nur bei tatsaechlicher Wertaenderung (E_D_FF_ANY), nicht bei jedem REQ.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			</Event>
+		</EventInputs>
+		<Plugs>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2886.67" y="-173.33"/>
+			<AdapterDeclaration Name="ET" Type="adapter::types::unidirectional::ATM" Comment="Elapsed time, Event nur bei Wertaenderung" x="3073.33" y="620"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="300" y="800"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time" x="300" y="1300"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="FB_TON" Type="iec61131::timers::FB_TON" x="1126.67" y="546.67">
+		</FB>
+		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="2006.67" y="-173.33">
+		</FB>
+		<FB Name="E_D_FF_ANY" Type="iec61499::events::E_D_FF_ANY" x="2006.67" y="620">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="FB_TON.REQ" dx1="80"/>
+			<Connection Source="REQ" Destination="FB_TON.REQ" dx1="993.33"/>
+			<Connection Source="FB_TON.CNF" Destination="E_D_FF.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF.EO" Destination="Q.E1"/>
+			<Connection Source="FB_TON.CNF" Destination="E_D_FF_ANY.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.EO" Destination="ET.E1"/>
+			<Connection Source="PT.E1" Destination="FB_TON.REQ" dx1="80"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="FB_TON.IN" dx1="260"/>
+			<Connection Source="PT.D1" Destination="FB_TON.PT" dx1="320"/>
+			<Connection Source="FB_TON.Q" Destination="E_D_FF.D" dx1="133.33"/>
+			<Connection Source="E_D_FF.Q" Destination="Q.D1"/>
+			<Connection Source="FB_TON.ET" Destination="E_D_FF_ANY.D" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.Q" Destination="ET.D1"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TP.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TP.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AX_ATM_FB_TP" Comment="standard timer function block (pulse) with AX/ATM Adapter, PT and ET as adapters">
-	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TP, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TP, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.  &#10; &#10;PT-Verhalten: PT.D1 liegt als reine Datenverbindung dauerhaft am internen&#10;FB_TP.PT an - der Adapter puffert/entprellt PT nicht. IN.E1, PT.E1 und das&#10;externe REQ sind gleichwertige Ausloeser fuer dieselbe FB_TP.REQ-Auswertung.&#10;Eine Aenderung von PT waehrend eines laufenden Impulses wirkt bei der&#10;naechsten Auswertung sofort mit dem dann aktuellen ET zusammen - siehe&#10;Technische Besonderheiten in der Doku fuer die Grenzfaelle PT=0 (Impuls kann&#10;fuer den Beobachter praktisch keine sichtbare TRUE-Phase haben) und schnell&#10;aufeinanderfolgende PT-Aenderungen. Vor dem allerersten PT.E1 liegt an&#10;FB_TP.PT der TIME-Standardwert T#0s an, nicht ein projektspezifischer Default.">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
 	</VersionInfo>
@@ -8,7 +8,7 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); gleichwertig zu IN.E1/PT.E1 (alle drei loesen dieselbe interne Neuauswertung aus). Anwendung haengt hier periodisch einen E_CYCLE an, damit ET auch ohne IN-/PT-Aenderung aktualisiert wird">
 			</Event>
 		</EventInputs>
 		<Plugs>
@@ -17,7 +17,7 @@
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="200" y="1400"/>
-			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Pulse time" x="200" y="1900"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Pulse time; live/nicht gelatched - PT.E1 loest wie IN.E1/REQ sofort eine Neuauswertung mit dem neuen PT-Wert aus, keine Entprellung. PT=0 laesst den Impuls bei der naechsten Auswertung bereits als abgelaufen gelten" x="200" y="1900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TP.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/timers/AX_ATM_FB_TP.fbt
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AX_ATM_FB_TP" Comment="standard timer function block (pulse) with AX/ATM Adapter, PT and ET as adapters">
+	<Identification Standard="61131-3" Classification="standard timer function block" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;Wie AX_FB_TP, aber PT (Socket) und ET (Plug) sind ATM-Adapter statt&#10;einfacher Datenvariablen, s. AX_ATM_FB_TON fuer die Begruendung.">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::timers">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request (non-triggering); Anwendung haengt hier periodisch einen E_CYCLE an, damit ET aktualisiert wird">
+			</Event>
+		</EventInputs>
+		<Plugs>
+			<AdapterDeclaration Name="Q" Type="adapter::types::unidirectional::AX" Comment="Output" x="2640" y="426.67"/>
+			<AdapterDeclaration Name="ET" Type="adapter::types::unidirectional::ATM" Comment="Elapsed time, Event nur bei Wertaenderung" x="2826.67" y="1220"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::AX" Comment="Input" x="200" y="1400"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Pulse time" x="200" y="1900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="FB_TP" Type="iec61131::timers::FB_TP" x="926.67" y="1146.67">
+		</FB>
+		<FB Name="E_D_FF" Type="iec61499::events::E_D_FF" x="1760" y="426.67">
+		</FB>
+		<FB Name="E_D_FF_ANY" Type="iec61499::events::E_D_FF_ANY" x="1760" y="1220">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="FB_TP.REQ" dx1="80"/>
+			<Connection Source="REQ" Destination="FB_TP.REQ" dx1="993.33"/>
+			<Connection Source="FB_TP.CNF" Destination="E_D_FF.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF.EO" Destination="Q.E1"/>
+			<Connection Source="FB_TP.CNF" Destination="E_D_FF_ANY.CLK" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.EO" Destination="ET.E1"/>
+			<Connection Source="PT.E1" Destination="FB_TP.REQ" dx1="146.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="FB_TP.IN" dx1="106.67"/>
+			<Connection Source="PT.D1" Destination="FB_TP.PT" dx1="220"/>
+			<Connection Source="FB_TP.Q" Destination="E_D_FF.D" dx1="133.33"/>
+			<Connection Source="E_D_FF.Q" Destination="Q.D1"/>
+			<Connection Source="FB_TP.ET" Destination="E_D_FF_ANY.D" dx1="66.67"/>
+			<Connection Source="E_D_FF_ANY.Q" Destination="ET.D1"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Synced from Getreideannahme, plus PT.E1 also re-triggering the
wrapped FB_TON/TOF/TP.REQ (so a changed preset time recomputes ET
immediately, not just on IN or the external E_CYCLE).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add ATM-compatible adapter function blocks for IEC 61131-3 timer types TON, TOF, and TP.

New Features:
- Introduce AX_ATM_FB_TON adapter function block for integrating TON timers into the ATM architecture.
- Introduce AX_ATM_FB_TOF adapter function block for integrating TOF timers into the ATM architecture.
- Introduce AX_ATM_FB_TP adapter function block for integrating TP timers into the ATM architecture.