### PR TITLE
Rename REAL conversion FBs for more accurate representation

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/bidirectional/REAL/AR2_REAL_TO_R.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/bidirectional/REAL/AR2_REAL_TO_R.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR2_X_TO_REAL" Comment="Composite FB for convert AR2 to REAL">
+<FBType Name="AR2_REAL_TO_R" Comment="Composite FB for convert REAL to AR2">
 	<Identification Standard="61499-2" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-04-24">
@@ -29,18 +29,18 @@
 				<Attribute Name="YPOSITION" Type="DINT" Value="47"/>
 			</VarDeclaration>
 		</OutputVars>
-		<Sockets>
-			<AdapterDeclaration Name="AR2_IN" Type="adapter::types::bidirectional::AR2" Comment="Adapter Input" x="700" y="-700"/>
-		</Sockets>
+		<Plugs>
+			<AdapterDeclaration Name="AR2_OUT" Type="adapter::types::bidirectional::AR2" Comment="Adapter Output" x="-3900" y="-500"/>
+		</Plugs>
 	</InterfaceList>
 	<FBNetwork>
 		<EventConnections>
-			<Connection Source="AR2_IN.EO1" Destination="CNF" dx1="2293.33"/>
-			<Connection Source="REQ" Destination="AR2_IN.EI1" dx1="2788.24"/>
+			<Connection Source="REQ" Destination="AR2_OUT.EO1" dx1="700"/>
+			<Connection Source="AR2_OUT.EI1" Destination="CNF" dx1="4760"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="AR2_IN.DO1" Destination="IN" dx1="2293.33"/>
-			<Connection Source="OUT" Destination="AR2_IN.DI1" dx1="2070.59"/>
+			<Connection Source="OUT" Destination="AR2_OUT.DO1" dx1="180"/>
+			<Connection Source="AR2_OUT.DI1" Destination="IN" dx1="4760"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/bidirectional/REAL/AR2_R_TO_REAL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/bidirectional/REAL/AR2_R_TO_REAL.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR2_REAL_TO_X" Comment="Composite FB for convert REAL to AR2">
+<FBType Name="AR2_R_TO_REAL" Comment="Composite FB for convert AR2 to REAL">
 	<Identification Standard="61499-2" Description="Copyright (c) 2024 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2024-04-24">
@@ -29,18 +29,18 @@
 				<Attribute Name="YPOSITION" Type="DINT" Value="47"/>
 			</VarDeclaration>
 		</OutputVars>
-		<Plugs>
-			<AdapterDeclaration Name="AR2_OUT" Type="adapter::types::bidirectional::AR2" Comment="Adapter Output" x="-3900" y="-500"/>
-		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="AR2_IN" Type="adapter::types::bidirectional::AR2" Comment="Adapter Input" x="700" y="-700"/>
+		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
 		<EventConnections>
-			<Connection Source="REQ" Destination="AR2_OUT.EO1" dx1="700"/>
-			<Connection Source="AR2_OUT.EI1" Destination="CNF" dx1="4760"/>
+			<Connection Source="AR2_IN.EO1" Destination="CNF" dx1="2293.33"/>
+			<Connection Source="REQ" Destination="AR2_IN.EI1" dx1="2788.24"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="OUT" Destination="AR2_OUT.DO1" dx1="180"/>
-			<Connection Source="AR2_OUT.DI1" Destination="IN" dx1="4760"/>
+			<Connection Source="AR2_IN.DO1" Destination="IN" dx1="2293.33"/>
+			<Connection Source="OUT" Destination="AR2_IN.DI1" dx1="2070.59"/>
 		</DataConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Updated the conversion function block names to more accurately reflect their functionality, replacing 'X' with 'R' to better distinguish between AR2_REAL and AR2_R conversions.

## Summary by Sourcery

Enhancements:
- Align REAL conversion FB names from AR2_REAL_TO_X/AR2_X_TO_REAL to AR2_REAL_TO_R/AR2_R_TO_REAL to better reflect their conversion semantics.