### PR TITLE
Add unidirectional TIME conversion adapters ATM_TIME_TO_TM and ATM_TM_TO_TIME

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_TIME_TO_TM.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_TIME_TO_TM.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_TIME_TO_TM" Comment="Composite FB for convert TIME to ATM">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Request to Adapter">
+				<With Var="OUT"/>
+			</Event>
+		</EventInputs>
+		<InputVars>
+			<VarDeclaration Name="OUT" Type="TIME"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="ATM_OUT" Type="adapter::types::unidirectional::ATM" Comment="Adapter Output" x="0" y="0"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="REQ" Destination="ATM_OUT.E1" dx1="1180"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="OUT" Destination="ATM_OUT.D1" dx1="1000"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_TM_TO_TIME.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_TM_TO_TIME.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_TM_TO_TIME" Comment="Composite FB for convert ATM to TIME">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Confirmation from Adapter">
+				<With Var="IN"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="IN" Type="TIME" Comment="Input data from Adapter"/>
+		</OutputVars>
+		<Sockets>
+			<AdapterDeclaration Name="ATM_IN" Type="adapter::types::unidirectional::ATM" Comment="Adapter Input" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="ATM_IN.E1" Destination="CNF" dx1="1000"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="ATM_IN.D1" Destination="IN" dx1="1486.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Introduce two composite function blocks for converting between TIME and unidirectional ATM adapter types. These additions enhance the system's ability to handle time-related data conversion in a standardized manner consistent with the Eclipse Public License 2.0.

## Summary by Sourcery

Add composite function blocks for unidirectional TIME conversion using ATM_TIME_TO_TM and ATM_TM_TO_TIME adapters.

New Features:
- Introduce ATM_TIME_TO_TM composite function block for converting TIME values to the corresponding ATM time adapter type.
- Introduce ATM_TM_TO_TIME composite function block for converting from the ATM time adapter type back to TIME values.