### PR TITLE
Add ATM_SUB, AR_DIVTIME, ATM_AR_MULTIME, ATM_AR_DIVTIME, ATM_ADD

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/AR_DIVTIME.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/AR_DIVTIME.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_MULTIME" Comment="Multiplies time value with numerical values">
+<FBType Name="AR_DIVTIME" Comment="Divides a time value by a number value">
 	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,27 +15,27 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="TIME" Comment="First funtion input"/>
+			<VarDeclaration Name="IN1" Type="TIME" Comment="Time input to be divided"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 multiplied by IN2" x="2300" y="-700"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 divided by IN2" x="2300" y="-700"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Second function input" x="0" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Divisor" x="0" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>
-		<FB Name="F_MULTIME" Type="iec61131::arithmetic::F_MULTIME" x="1100" y="-700">
+		<FB Name="F_DIVTIME" Type="iec61131::arithmetic::F_DIVTIME" x="1100" y="-700">
 		</FB>
 		<EventConnections>
-			<Connection Source="F_MULTIME.CNF" Destination="OUT.E1" dx1="246.67"/>
-			<Connection Source="IN2.E1" Destination="F_MULTIME.REQ" dx1="406.67"/>
-			<Connection Source="REQ" Destination="F_MULTIME.REQ" dx1="1780"/>
+			<Connection Source="F_DIVTIME.CNF" Destination="OUT.E1" dx1="246.67"/>
+			<Connection Source="IN2.E1" Destination="F_DIVTIME.REQ" dx1="406.67"/>
+			<Connection Source="REQ" Destination="F_DIVTIME.REQ" dx1="1780"/>
 		</EventConnections>
 		<DataConnections>
-			<Connection Source="F_MULTIME.OUT" Destination="OUT.D1"/>
-			<Connection Source="IN2.D1" Destination="F_MULTIME.IN2" dx1="566.67"/>
-			<Connection Source="IN1" Destination="F_MULTIME.IN1" dx1="1200"/>
+			<Connection Source="F_DIVTIME.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN2.D1" Destination="F_DIVTIME.IN2" dx1="566.67"/>
+			<Connection Source="IN1" Destination="F_DIVTIME.IN1" dx1="1200"/>
 		</DataConnections>
 	</FBNetwork>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_ADD_2" Comment="FB to calculate arithmetic ADD (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::arithmetic">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="ADD input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="ADD input 2"/>
+		</Sockets>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="ADD result"/>
+		</Plugs>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_ADD'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_ADD_3" Comment="FB to calculate arithmetic ADD (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::arithmetic">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="ADD input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="ADD input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ATM" Comment="ADD input 3"/>
+		</Sockets>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="ADD result"/>
+		</Plugs>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_ADD'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_ADD_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_ADD_4" Comment="FB to calculate arithmetic ADD (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::arithmetic">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="ADD input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="ADD input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::ATM" Comment="ADD input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::ATM" Comment="ADD input 4"/>
+		</Sockets>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="ADD result"/>
+		</Plugs>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_ADD'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_AR_DIVTIME.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_AR_DIVTIME.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_AR_DIVTIME" Comment="Divides a time value by a number value, both via adapters (IN1 as ATM socket instead of a fixed TIME literal, unlike AR_DIVTIME)">
+	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-09-12">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::arithmetic">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 divided by IN2" x="2300" y="-700"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="Time input to be divided" x="0" y="-700"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Divisor" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_DIVTIME" Type="iec61131::arithmetic::F_DIVTIME" x="1100" y="-700">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_DIVTIME.CNF" Destination="OUT.E1" dx1="246.67"/>
+			<Connection Source="IN1.E1" Destination="F_DIVTIME.REQ" dx1="406.67"/>
+			<Connection Source="IN2.E1" Destination="F_DIVTIME.REQ" dx1="406.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_DIVTIME.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_DIVTIME.IN1" dx1="566.67"/>
+			<Connection Source="IN2.D1" Destination="F_DIVTIME.IN2" dx1="566.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_AR_MULTIME.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_AR_MULTIME.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_MULTIME" Comment="Multiplies time value with numerical values">
+<FBType Name="ATM_AR_MULTIME" Comment="Multiplies time value with numerical values, both via adapters (IN1 as ATM socket instead of a fixed TIME literal, unlike AR_MULTIME)">
 	<Identification Standard="61131-3" Classification="standard arithmetic function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -9,18 +9,11 @@
 	<CompilerInfo packageName="adapter::iec61131::arithmetic">
 	</CompilerInfo>
 	<InterfaceList>
-		<EventInputs>
-			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
-				<With Var="IN1"/>
-			</Event>
-		</EventInputs>
-		<InputVars>
-			<VarDeclaration Name="IN1" Type="TIME" Comment="First funtion input"/>
-		</InputVars>
 		<Plugs>
 			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN1 multiplied by IN2" x="2300" y="-700"/>
 		</Plugs>
 		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="First function input" x="0" y="-700"/>
 			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Second function input" x="0" y="0"/>
 		</Sockets>
 	</InterfaceList>
@@ -29,13 +22,13 @@
 		</FB>
 		<EventConnections>
 			<Connection Source="F_MULTIME.CNF" Destination="OUT.E1" dx1="246.67"/>
+			<Connection Source="IN1.E1" Destination="F_MULTIME.REQ" dx1="406.67"/>
 			<Connection Source="IN2.E1" Destination="F_MULTIME.REQ" dx1="406.67"/>
-			<Connection Source="REQ" Destination="F_MULTIME.REQ" dx1="1780"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="F_MULTIME.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_MULTIME.IN1" dx1="566.67"/>
 			<Connection Source="IN2.D1" Destination="F_MULTIME.IN2" dx1="566.67"/>
-			<Connection Source="IN1" Destination="F_MULTIME.IN1" dx1="1200"/>
 		</DataConnections>
 	</FBNetwork>
 	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_SUB.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/arithmetic/ATM_SUB.fbt
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_SUB" Comment="Subtracts two TIME values via ATM adapters (F_SUB is ANY_MAGNITUDE, works directly on TIME)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::arithmetic">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="IN2 subtracted from IN1" x="4000" y="-700"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::ATM" Comment="First function input" x="0" y="-700"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::ATM" Comment="Second function input" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_SUB" Type="iec61131::arithmetic::F_SUB" x="1100" y="-700">
+		</FB>
+		<FB Name="E_D_FF_ANY" Type="iec61499::events::E_D_FF_ANY" x="3000" y="-700">
+		</FB>
+		<FB Name="F_MOVE" Type="iec61131::selection::F_MOVE" x="2200" y="-700">
+			<Attribute Name="DataType" Value="TIME"/>
+		</FB>
+		<EventConnections>
+			<Connection Source="IN1.E1" Destination="F_SUB.REQ" dx1="406.67"/>
+			<Connection Source="IN2.E1" Destination="F_SUB.REQ" dx1="406.67"/>
+			<Connection Source="E_D_FF_ANY.EO" Destination="OUT.E1"/>
+			<Connection Source="F_SUB.CNF" Destination="F_MOVE.REQ"/>
+			<Connection Source="F_MOVE.CNF" Destination="E_D_FF_ANY.CLK"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN1.D1" Destination="F_SUB.IN1" dx1="566.67"/>
+			<Connection Source="IN2.D1" Destination="F_SUB.IN2" dx1="566.67"/>
+			<Connection Source="F_SUB.OUT" Destination="F_MOVE.IN"/>
+			<Connection Source="E_D_FF_ANY.Q" Destination="OUT.D1"/>
+			<Connection Source="F_MOVE.OUT" Destination="E_D_FF_ANY.D"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Synced from Getreideannahme:
- ATM_SUB: subtracts two TIME values via ATM sockets (F_SUB is
  ANY_MAGNITUDE), with change-detection on OUT.
- AR_DIVTIME / ATM_AR_MULTIME / ATM_AR_DIVTIME: F_DIVTIME/F_MULTIME
  wrappers mirroring AR_MULTIME's style, including the fully
  adapter-ized IN1-as-ATM-socket variants.
- ATM_ADD: generic FB (GEN_ATM_ADD) mirroring AR_ADD_2.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add new TIME arithmetic function blocks and adapter-based variants for division, multiplication, addition, and subtraction in the IEC 61131-3 arithmetic library.

New Features:
- Introduce AR_DIVTIME to provide TIME division functionality consistent with existing AR_MULTIME style wrappers.
- Add ATM_SUB function block to subtract TIME values via ATM sockets with change detection on the output.
- Add ATM_AR_MULTIME and ATM_AR_DIVTIME adapter-based wrappers for TIME multiplication and division using ATM sockets.
- Add ATM_ADD generic function block (GEN_ATM_ADD) for adapter-based TIME addition mirroring AR_ADD_2.