### PR TITLE
Add ATM_SPLIT_2/3/4, mirroring AR_SPLIT_2/3/4

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_SPLIT_2" Comment="SPLIT 1 ATM into 2 ATM (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::unidirectional">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_SPLIT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_SPLIT_3" Comment="SPLIT 1 ATM into 3 ATM (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::unidirectional">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_SPLIT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/unidirectional/TIME/ATM_SPLIT_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_SPLIT_4" Comment="SPLIT 1 ATM into 4 ATM (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::unidirectional">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT1" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT2" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT3" Type="adapter::types::unidirectional::ATM"/>
+			<AdapterDeclaration Name="OUT4" Type="adapter::types::unidirectional::ATM"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_ATM_SPLIT'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Generic FBs (GEN_ATM_SPLIT) fanning one ATM socket out to 2/3/4 ATM
plugs. Synced from Getreideannahme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add generic ATM splitter function blocks that fan out a single ATM socket to multiple plugs.

New Features:
- Introduce ATM_SPLIT_2 function block for splitting one ATM socket into two outputs.
- Introduce ATM_SPLIT_3 function block for splitting one ATM socket into three outputs.
- Introduce ATM_SPLIT_4 function block for splitting one ATM socket into four outputs.