### PR TITLE
Add ATM_IN_*_TO_* TIME-unit conversion adapters and initval_A* family

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ADI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ADI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_MS_TO_ADI" Comment="Convert TIME (via ATM adapter) in MS to DINT (via ADI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_MS_TO_DINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="TIME value of IN expressed in MS as DINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_MS_TO_DINT" Type="iec61131::conversion::F_TIME_IN_MS_TO_DINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_MS_TO_DINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_DINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_MS_TO_DINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_DINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ALI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ALI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_MS_TO_ALI" Comment="Convert TIME (via ATM adapter) in MS to LINT (via ALI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_MS_TO_LINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="TIME value of IN expressed in MS as LINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_MS_TO_LINT" Type="iec61131::conversion::F_TIME_IN_MS_TO_LINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_MS_TO_LINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_LINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_MS_TO_LINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_LINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_ALR.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_MS_TO_ALR" Comment="Convert TIME (via ATM adapter) in MS to LREAL (via ALR adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_MS_TO_LREAL"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="TIME value of IN expressed in MS as LREAL" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_MS_TO_LREAL" Type="iec61131::conversion::F_TIME_IN_MS_TO_LREAL" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_MS_TO_LREAL.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_LREAL.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_MS_TO_LREAL.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_LREAL.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_AUDI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_MS_TO_AUDI" Comment="Convert TIME (via ATM adapter) in MS to UDINT (via AUDI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_MS_TO_UDINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="TIME value of IN expressed in MS as UDINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_MS_TO_UDINT" Type="iec61131::conversion::F_TIME_IN_MS_TO_UDINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_MS_TO_UDINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_UDINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_MS_TO_UDINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_UDINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_AULI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_MS_TO_AULI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_MS_TO_AULI" Comment="Convert TIME (via ATM adapter) in MS to ULINT (via AULI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_MS_TO_ULINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="TIME value of IN expressed in MS as ULINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_MS_TO_ULINT" Type="iec61131::conversion::F_TIME_IN_MS_TO_ULINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_MS_TO_ULINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_ULINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_MS_TO_ULINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_MS_TO_ULINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ADI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ADI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_NS_TO_ADI" Comment="Convert TIME (via ATM adapter) in NS to DINT (via ADI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_NS_TO_DINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="TIME value of IN expressed in NS as DINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_NS_TO_DINT" Type="iec61131::conversion::F_TIME_IN_NS_TO_DINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_NS_TO_DINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_DINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_NS_TO_DINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_DINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ALI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ALI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_NS_TO_ALI" Comment="Convert TIME (via ATM adapter) in NS to LINT (via ALI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_NS_TO_LINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="TIME value of IN expressed in NS as LINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_NS_TO_LINT" Type="iec61131::conversion::F_TIME_IN_NS_TO_LINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_NS_TO_LINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_LINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_NS_TO_LINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_LINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_ALR.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_NS_TO_ALR" Comment="Convert TIME (via ATM adapter) in NS to LREAL (via ALR adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_NS_TO_LREAL"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="TIME value of IN expressed in NS as LREAL" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_NS_TO_LREAL" Type="iec61131::conversion::F_TIME_IN_NS_TO_LREAL" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_NS_TO_LREAL.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_LREAL.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_NS_TO_LREAL.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_LREAL.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_AUDI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_NS_TO_AUDI" Comment="Convert TIME (via ATM adapter) in NS to UDINT (via AUDI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_NS_TO_UDINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="TIME value of IN expressed in NS as UDINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_NS_TO_UDINT" Type="iec61131::conversion::F_TIME_IN_NS_TO_UDINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_NS_TO_UDINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_UDINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_NS_TO_UDINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_UDINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_AULI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_NS_TO_AULI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_NS_TO_AULI" Comment="Convert TIME (via ATM adapter) in NS to ULINT (via AULI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_NS_TO_ULINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="TIME value of IN expressed in NS as ULINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_NS_TO_ULINT" Type="iec61131::conversion::F_TIME_IN_NS_TO_ULINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_NS_TO_ULINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_ULINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_NS_TO_ULINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_NS_TO_ULINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ADI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ADI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_S_TO_ADI" Comment="Convert TIME (via ATM adapter) in S to DINT (via ADI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_S_TO_DINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="TIME value of IN expressed in S as DINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_S_TO_DINT" Type="iec61131::conversion::F_TIME_IN_S_TO_DINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_S_TO_DINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_DINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_S_TO_DINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_DINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ALI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ALI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_S_TO_ALI" Comment="Convert TIME (via ATM adapter) in S to LINT (via ALI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_S_TO_LINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="TIME value of IN expressed in S as LINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_S_TO_LINT" Type="iec61131::conversion::F_TIME_IN_S_TO_LINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_S_TO_LINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_LINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_S_TO_LINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_LINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_ALR.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_S_TO_ALR" Comment="Convert TIME (via ATM adapter) in S to LREAL (via ALR adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_S_TO_LREAL"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="TIME value of IN expressed in S as LREAL" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_S_TO_LREAL" Type="iec61131::conversion::F_TIME_IN_S_TO_LREAL" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_S_TO_LREAL.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_LREAL.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_S_TO_LREAL.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_LREAL.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_AUDI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_S_TO_AUDI" Comment="Convert TIME (via ATM adapter) in S to UDINT (via AUDI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_S_TO_UDINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="TIME value of IN expressed in S as UDINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_S_TO_UDINT" Type="iec61131::conversion::F_TIME_IN_S_TO_UDINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_S_TO_UDINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_UDINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_S_TO_UDINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_UDINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_AULI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_S_TO_AULI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_S_TO_AULI" Comment="Convert TIME (via ATM adapter) in S to ULINT (via AULI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_S_TO_ULINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="TIME value of IN expressed in S as ULINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_S_TO_ULINT" Type="iec61131::conversion::F_TIME_IN_S_TO_ULINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_S_TO_ULINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_ULINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_S_TO_ULINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_S_TO_ULINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ADI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ADI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_US_TO_ADI" Comment="Convert TIME (via ATM adapter) in US to DINT (via ADI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_US_TO_DINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="TIME value of IN expressed in US as DINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_US_TO_DINT" Type="iec61131::conversion::F_TIME_IN_US_TO_DINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_US_TO_DINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_DINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_US_TO_DINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_DINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ALI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ALI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_US_TO_ALI" Comment="Convert TIME (via ATM adapter) in US to LINT (via ALI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_US_TO_LINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="TIME value of IN expressed in US as LINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_US_TO_LINT" Type="iec61131::conversion::F_TIME_IN_US_TO_LINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_US_TO_LINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_LINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_US_TO_LINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_LINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_ALR.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_US_TO_ALR" Comment="Convert TIME (via ATM adapter) in US to LREAL (via ALR adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_US_TO_LREAL"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="TIME value of IN expressed in US as LREAL" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_US_TO_LREAL" Type="iec61131::conversion::F_TIME_IN_US_TO_LREAL" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_US_TO_LREAL.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_LREAL.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_US_TO_LREAL.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_LREAL.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_AUDI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_US_TO_AUDI" Comment="Convert TIME (via ATM adapter) in US to UDINT (via AUDI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_US_TO_UDINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="TIME value of IN expressed in US as UDINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_US_TO_UDINT" Type="iec61131::conversion::F_TIME_IN_US_TO_UDINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_US_TO_UDINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_UDINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_US_TO_UDINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_UDINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_AULI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/conversion/unidirectional/TIME/ATM_IN_US_TO_AULI.fbt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="ATM_IN_US_TO_AULI" Comment="Convert TIME (via ATM adapter) in US to ULINT (via AULI adapter)">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::conversion::unidirectional">
+		<Import declaration="iec61131::conversion::F_TIME_IN_US_TO_ULINT"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="TIME value of IN expressed in US as ULINT" x="2000" y="0"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN" Type="adapter::types::unidirectional::ATM" Comment="Time value to convert" x="0" y="0"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_TIME_IN_US_TO_ULINT" Type="iec61131::conversion::F_TIME_IN_US_TO_ULINT" x="900" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="IN.E1" Destination="F_TIME_IN_US_TO_ULINT.REQ" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_ULINT.CNF" Destination="OUT.E1" dx1="450"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="IN.D1" Destination="F_TIME_IN_US_TO_ULINT.IN" dx1="450"/>
+			<Connection Source="F_TIME_IN_US_TO_ULINT.OUT" Destination="OUT.D1" dx1="450"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BYTE/initval/initval_AB.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/BYTE/initval/initval_AB.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AB" Comment="a initval for AB Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AB::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="BYTE"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="will output BYTE default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/DINT/initval/initval_ADI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/DINT/initval/initval_ADI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_ADI" Comment="a initval for ADI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::ADI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="DINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ADI" Comment="will output DINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/DWORD/initval/initval_AD.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/DWORD/initval/initval_AD.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AD" Comment="a initval for AD Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AD::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="DWORD"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="will output DWORD default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/INT/initval/initval_AI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/INT/initval/initval_AI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AI" Comment="a initval for AI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="INT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AI" Comment="will output INT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LINT/initval/initval_ALI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LINT/initval/initval_ALI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_ALI" Comment="a initval for ALI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::ALI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="LINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALI" Comment="will output LINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LREAL/initval/initval_ALR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LREAL/initval/initval_ALR.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_ALR" Comment="a initval for ALR Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::ALR::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="LREAL"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ALR" Comment="will output LREAL default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LWORD/initval/initval_AL.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/LWORD/initval/initval_AL.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AL" Comment="a initval for AL Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AL::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="LWORD"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="will output LWORD default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/QUARTER/initval/initval_AQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/QUARTER/initval/initval_AQ.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AQ" Comment="a initval for AQ Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AQ::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="BYTE"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="will output BYTE default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/REAL/initval/initval_AR.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/REAL/initval/initval_AR.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AR" Comment="a initval for AR Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AR::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="REAL"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AR" Comment="will output REAL default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/SINT/initval/initval_AS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/SINT/initval/initval_AS.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AS" Comment="a initval for AS Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AS::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="SINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AS" Comment="will output SINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/STRING/initval/initval_AIS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/STRING/initval/initval_AIS.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AIS" Comment="a initval for AIS Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AIS::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="STRING"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIS" Comment="will output STRING default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/TIME/initval/initval_ATM.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/TIME/initval/initval_ATM.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_ATM" Comment="a initval for ATM Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::ATM::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="TIME"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::ATM" Comment="will output TIME default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/UDINT/initval/initval_AUDI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/UDINT/initval/initval_AUDI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AUDI" Comment="a initval for AUDI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AUDI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="UDINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUDI" Comment="will output UDINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/UINT/initval/initval_AUI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/UINT/initval/initval_AUI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AUI" Comment="a initval for AUI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AUI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="UINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUI" Comment="will output UINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/ULINT/initval/initval_AULI.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/ULINT/initval/initval_AULI.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AULI" Comment="a initval for AULI Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AULI::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="ULINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AULI" Comment="will output ULINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/USINT/initval/initval_AUS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/USINT/initval/initval_AUS.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AUS" Comment="a initval for AUS Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AUS::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="USINT"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AUS" Comment="will output USINT default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/WORD/initval/initval_AW.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/WORD/initval/initval_AW.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AW" Comment="a initval for AW Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AW::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="WORD"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="will output WORD default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/WSTRING/initval/initval_AIWS.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/types/unidirectional/WSTRING/initval/initval_AIWS.fbt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="initval_AIWS" Comment="a initval for AIWS Interface">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::types::unidirectional::AIWS::initval">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="INIT_VAL"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="INIT_VAL" Type="WSTRING"/>
+		</InputVars>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AIWS" Comment="will output WSTRING default at INIT" x="66.67" y="66.67"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<EventConnections>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="INIT" Destination="OUT.E1" dx1="1240"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="INIT_VAL" Destination="OUT.D1" dx1="1146.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>


### PR DESCRIPTION
- conversion/unidirectional/TIME: ATM_IN_{MS,NS,S,US}_TO_{ADI,ALI,ALR,AUDI,AULI},
  wrapping the standard iec61131::conversion::F_TIME_IN_x_TO_y functions to
  convert an ATM (TIME) socket into a numeric adapter plug.
- types/unidirectional/*/initval: initval_A<X> for all remaining unidirectional
  adapter types, mirroring the existing initval_AX (BOOL) pattern.

## Summary by Sourcery

Add TIME-based unidirectional conversion adapters and complete the initval adapter family for remaining scalar types.

New Features:
- Introduce ATM_IN_*_TO_* unidirectional TIME conversion adapters for converting TIME sockets in various units to numeric adapter plugs.
- Provide initval_A* unidirectional adapter blocks for all remaining scalar data types, aligning initialization support across the type library.