### PR TITLE
Add AR comparison adapters and improve operand clarity

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_EQ" Comment="equal">
+<FBType Name="AR_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 = IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 = IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_EQ.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_EQ" Comment="equal">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_EQ" Type="iec61131::comparison::F_EQ" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_EQ.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_EQ.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_EQ.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_EQ.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_EQ.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_EQ.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_GE" Comment="greater or equal">
+<FBType Name="AR_GE" Comment="greater or equal (IN1 &gt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 &gt;= IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 &gt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GE.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_GE" Comment="greater or equal">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt;= value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_GE" Type="iec61131::comparison::F_GE" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_GE.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_GE.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_GE.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_GE.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_GE.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_GE.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GT.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_GT" Comment="greater than">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_GT" Type="iec61131::comparison::F_GT" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_GT.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_GT.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_GT.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_GT.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_GT.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_GT.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_GT" Comment="greater than">
+<FBType Name="AR_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 &gt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 &gt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LE.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_LE" Comment="less or equal">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_LE" Type="iec61131::comparison::F_LE" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_LE.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_LE.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_LE.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_LE.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_LE.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_LE.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_LE" Comment="less or equal">
+<FBType Name="AR_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LT.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_LT" Comment="less than">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_LT" Type="iec61131::comparison::F_LT" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_LT.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_LT.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_LT.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_LT.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_LT.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_LT.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_LT" Comment="less than">
+<FBType Name="AR_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 &lt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 &lt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_NE.fbt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AR_NE" Comment="not equal">
+	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="TU Wien ACIN" Version="1.0" Author="Monika Wenger" Date="2013-03-13">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::iec61131::comparison">
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="F_NE" Type="iec61131::comparison::F_NE" x="1600" y="500">
+		</FB>
+		<EventConnections>
+			<Connection Source="F_NE.CNF" Destination="OUT.E1"/>
+			<Connection Source="IN1.E1" Destination="F_NE.REQ" dx1="800"/>
+			<Connection Source="IN2.E1" Destination="F_NE.REQ" dx1="513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="F_NE.OUT" Destination="OUT.D1"/>
+			<Connection Source="IN1.D1" Destination="F_NE.IN1" dx1="200"/>
+			<Connection Source="IN2.D1" Destination="F_NE.IN2" dx1="733.33"/>
+		</DataConnections>
+	</FBNetwork>
+	<Service RightInterface="RESOURCE" LeftInterface="APPLICATION">
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AR_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AR_NE" Comment="not equal">
+<FBType Name="AR_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AR" Comment="Input value 1 -- left operand (IN1 != IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AR" Comment="Input value 2 -- right operand (IN1 != IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_EQ" Comment="equal">
+<FBType Name="AUDI_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 = IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 = IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_GE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_GE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_GE" Comment="greater or equal">
+<FBType Name="AUDI_GE" Comment="greater or equal (IN1 &gt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &gt;= IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &gt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_GT" Comment="greater than">
+<FBType Name="AUDI_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &gt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &gt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_LE" Comment="less or equal">
+<FBType Name="AUDI_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_LT" Comment="less than">
+<FBType Name="AUDI_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &lt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &lt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_NE" Comment="not equal">
+<FBType Name="AUDI_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 != IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 != IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_EQ" Comment="equal">
+<FBType Name="AUDI_UDINT_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 = IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 = IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_GE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_GE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_GE" Comment="greater or equal">
+<FBType Name="AUDI_UDINT_GE" Comment="greater or equal (IN1 &gt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &gt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &gt;= IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_GT" Comment="greater than">
+<FBType Name="AUDI_UDINT_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &gt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &gt; IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_LE" Comment="less or equal">
+<FBType Name="AUDI_UDINT_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_LT" Comment="less than">
+<FBType Name="AUDI_UDINT_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &lt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 &lt; IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUDI_UDINT_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUDI_UDINT_NE" Comment="not equal">
+<FBType Name="AUDI_UDINT_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 != IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUDI" Comment="Input value 1 -- left operand (IN1 != IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_EQ" Comment="equal">
+<FBType Name="AUI_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 = IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 = IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_GT" Comment="greater than">
+<FBType Name="AUI_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &gt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &gt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_LE" Comment="less or equal">
+<FBType Name="AUI_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_LT" Comment="less than">
+<FBType Name="AUI_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &lt; IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &lt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_NE" Comment="not equal">
+<FBType Name="AUI_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -10,11 +10,11 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 != IN2)" x="100" y="0"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 != IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_UDINT_EQ" Comment="equal">
+<FBType Name="AUI_UDINT_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 = IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 = IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_UDINT_GT" Comment="greater than">
+<FBType Name="AUI_UDINT_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &gt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &gt; IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_UDINT_LE" Comment="less or equal">
+<FBType Name="AUI_UDINT_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_UDINT_LT" Comment="less than">
+<FBType Name="AUI_UDINT_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 &lt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 &lt; IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/AUI_UDINT_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="AUI_UDINT_NE" Comment="not equal">
+<FBType Name="AUI_UDINT_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2"/>
+			<VarDeclaration Name="IN2" Type="UDINT" Comment="Input value 2 -- right operand (IN1 != IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1" x="100" y="0"/>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AUI" Comment="Input value 1 -- left operand (IN1 != IN2)" x="100" y="0"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_EQ" Comment="equal">
+<FBType Name="UDINT_AUDI_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 = IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 = IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_GE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_GE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_GE" Comment="greater or equal">
+<FBType Name="UDINT_AUDI_GE" Comment="greater or equal (IN1 &gt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &gt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &gt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_GT" Comment="greater than">
+<FBType Name="UDINT_AUDI_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &gt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &gt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_LE" Comment="less or equal">
+<FBType Name="UDINT_AUDI_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_LT" Comment="less than">
+<FBType Name="UDINT_AUDI_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &lt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 &lt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUDI_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUDI_NE" Comment="not equal">
+<FBType Name="UDINT_AUDI_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN\n \nThis program and the accompanying materials are made\navailable under the terms of the Eclipse Public License 2.0\nwhich is available at https://www.eclipse.org/legal/epl-2.0/\n\nSPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 != IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUDI" Comment="Input value 2 -- right operand (IN1 != IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_EQ.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_EQ.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUI_EQ" Comment="equal">
+<FBType Name="UDINT_AUI_EQ" Comment="equal (IN1 = IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 = IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 = value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 = IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 = IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_GT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_GT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUI_GT" Comment="greater than">
+<FBType Name="UDINT_AUI_GT" Comment="greater than (IN1 &gt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &gt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &gt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &gt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &gt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_LE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_LE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUI_LE" Comment="less or equal">
+<FBType Name="UDINT_AUI_LE" Comment="less or equal (IN1 &lt;= IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &lt;= IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt;= value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt;= IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &lt;= IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_LT.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_LT.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUI_LT" Comment="less than">
+<FBType Name="UDINT_AUI_LT" Comment="less than (IN1 &lt; IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 &lt; IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 &lt; value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 &lt; IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 &lt; IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_NE.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/iec61131-3/comparison/UDINT_AUI_NE.fbt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FBType Name="UDINT_AUI_NE" Comment="not equal">
+<FBType Name="UDINT_AUI_NE" Comment="not equal (IN1 != IN2 = TRUE)">
 	<Identification Standard="61131-3" Classification="standard comparison function" Description="Copyright (c) 2013 TU Wien ACIN&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
 	</Identification>
 	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
@@ -15,13 +15,13 @@
 			</Event>
 		</EventInputs>
 		<InputVars>
-			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1"/>
+			<VarDeclaration Name="IN1" Type="ANY_ELEMENTARY" Comment="Input value 1 -- left operand (IN1 != IN2)"/>
 		</InputVars>
 		<Plugs>
-			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="value 1 != value2 = true" x="3000" y="500"/>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AX" Comment="IN1 != IN2 = TRUE" x="3000" y="500"/>
 		</Plugs>
 		<Sockets>
-			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2" x="100" y="900"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AUI" Comment="Input value 2 -- right operand (IN1 != IN2)" x="100" y="900"/>
 		</Sockets>
 	</InterfaceList>
 	<FBNetwork>


### PR DESCRIPTION
Introduces new comparison adapters: AR_EQ, AR_GE, AR_GT, AR_LE, AR_LT, and AR_NE.

Enhances clarity for existing adapters by explicitly defining the order of operands:
- Adjusts comments to specify which operand is considered the left or right.
- Improves documentation within the adapter declaration to ensure consistency in understanding the adapter's behavior.

These changes contribute to a more robust adapter functionality and improve code readability for users.

## Summary by Sourcery

Add new generic AR_* comparison adapters and clarify operand roles across existing comparison adapter blocks.

New Features:
- Introduce AR_EQ, AR_GE, AR_GT, AR_LE, AR_LT, and AR_NE adapter function blocks for comparison operations.

Enhancements:
- Align and clarify documentation/comments in existing AUDI_*, AUI_*, and UDINT_* comparison adapters to explicitly state left/right operand semantics.