### PR TITLE
Add bitwise AND/OR/XOR generic FBs for bit-string adapter types

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_AND_2" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="AND input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_AND_3" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="AND input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_AND_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_AND_4" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="AND input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="AND input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_10.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_10.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_10" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AB" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AB" Comment="OR input 9"/>
+			<AdapterDeclaration Name="IN10" Type="adapter::types::unidirectional::AB" Comment="OR input 10"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_2" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_3" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_4" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_5" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_6" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="OR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_7" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="OR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_8" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AB" Comment="OR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_9.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_OR_9.fbt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_OR_9" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AB" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AB" Comment="OR input 9"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_2" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_3" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_4" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="XOR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_5" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="XOR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_6" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="XOR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_7" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="XOR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AB_XOR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AB_XOR_8" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AB" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AB" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AB" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AB" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AB" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AB" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AB" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AB" Comment="XOR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AB" Comment="XOR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AB_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_AND_2" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="AND input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_AND_3" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="AND input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_AND_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_AND_4" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="AND input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="AND input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_10.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_10.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_10" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AD" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AD" Comment="OR input 9"/>
+			<AdapterDeclaration Name="IN10" Type="adapter::types::unidirectional::AD" Comment="OR input 10"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_2" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_3" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_4" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_5" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_6" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="OR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_7" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="OR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_8" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AD" Comment="OR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_9.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_OR_9.fbt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_OR_9" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AD" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AD" Comment="OR input 9"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_2" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_3" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_4" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="XOR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_5" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="XOR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_6" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="XOR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_7" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="XOR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AD_XOR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AD_XOR_8" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AD" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AD" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AD" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AD" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AD" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AD" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AD" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AD" Comment="XOR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AD" Comment="XOR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AD_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_AND_2" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="AND input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_AND_3" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="AND input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_AND_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_AND_4" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="AND input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="AND input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_10.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_10.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_10" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AL" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AL" Comment="OR input 9"/>
+			<AdapterDeclaration Name="IN10" Type="adapter::types::unidirectional::AL" Comment="OR input 10"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_2" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_3" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_4" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_5" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_6" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="OR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_7" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="OR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_8" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AL" Comment="OR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_9.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_OR_9.fbt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_OR_9" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AL" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AL" Comment="OR input 9"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_2" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_3" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_4" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="XOR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_5" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="XOR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_6" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="XOR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_7" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="XOR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AL_XOR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AL_XOR_8" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AL" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AL" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AL" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AL" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AL" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AL" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AL" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AL" Comment="XOR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AL" Comment="XOR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AL_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_AND_2" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="AND input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_AND_3" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="AND input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_AND_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_AND_4" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="AND input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="AND input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_10.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_10.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_10" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AQ" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AQ" Comment="OR input 9"/>
+			<AdapterDeclaration Name="IN10" Type="adapter::types::unidirectional::AQ" Comment="OR input 10"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_2" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_3" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_4" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_5" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_6" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="OR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_7" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="OR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_8" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AQ" Comment="OR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_9.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_OR_9.fbt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_OR_9" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AQ" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AQ" Comment="OR input 9"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_2" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_3" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_4" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="XOR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_5" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="XOR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_6" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="XOR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_7" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="XOR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AQ_XOR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AQ_XOR_8" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AQ" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AQ" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AQ" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AQ" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AQ" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AQ" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AQ" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AQ" Comment="XOR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AQ" Comment="XOR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AQ_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_AND_2" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="AND input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_AND_3" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="AND input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_AND_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_AND_4" Comment="FB to calculate boolean AND (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="AND result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="AND input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="AND input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="AND input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="AND input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_AND'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_10.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_10.fbt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_10" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AW" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AW" Comment="OR input 9"/>
+			<AdapterDeclaration Name="IN10" Type="adapter::types::unidirectional::AW" Comment="OR input 10"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_2" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_3" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_4" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_5" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_6" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="OR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_7" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="OR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_8" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AW" Comment="OR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_9.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_OR_9.fbt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_OR_9" Comment="FB to calculate boolean OR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="OR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="OR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="OR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="OR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="OR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="OR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="OR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="OR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AW" Comment="OR input 8"/>
+			<AdapterDeclaration Name="IN9" Type="adapter::types::unidirectional::AW" Comment="OR input 9"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_OR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_2.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_2.fbt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_2" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_3.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_3.fbt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_3" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_4.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_4.fbt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_4" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="XOR input 4"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_5.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_5.fbt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_5" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="XOR input 5"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_6.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_6.fbt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_6" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="XOR input 6"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_7.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_7.fbt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_7" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="XOR input 7"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_8.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/booleanOperators/AW_XOR_8.fbt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AW_XOR_8" Comment="FB to calculate boolean XOR (generic FB) Adapter-Ausgang wird nur bei Wertänderung aktualisiert (Event nur bei tatsächlicher Änderung).">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-13" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::booleanOperators">
+		<Import declaration="eclipse4diac::core::GenericClassName"/>
+	</CompilerInfo>
+	<InterfaceList>
+		<Plugs>
+			<AdapterDeclaration Name="OUT" Type="adapter::types::unidirectional::AW" Comment="XOR result"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="IN1" Type="adapter::types::unidirectional::AW" Comment="XOR input 1"/>
+			<AdapterDeclaration Name="IN2" Type="adapter::types::unidirectional::AW" Comment="XOR input 2"/>
+			<AdapterDeclaration Name="IN3" Type="adapter::types::unidirectional::AW" Comment="XOR input 3"/>
+			<AdapterDeclaration Name="IN4" Type="adapter::types::unidirectional::AW" Comment="XOR input 4"/>
+			<AdapterDeclaration Name="IN5" Type="adapter::types::unidirectional::AW" Comment="XOR input 5"/>
+			<AdapterDeclaration Name="IN6" Type="adapter::types::unidirectional::AW" Comment="XOR input 6"/>
+			<AdapterDeclaration Name="IN7" Type="adapter::types::unidirectional::AW" Comment="XOR input 7"/>
+			<AdapterDeclaration Name="IN8" Type="adapter::types::unidirectional::AW" Comment="XOR input 8"/>
+		</Sockets>
+	</InterfaceList>
+	<Attribute Name="eclipse4diac::core::GenericClassName" Value="'GEN_AW_XOR'"/>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Mirror the existing AX_AND/AX_OR/AX_XOR generic FB pattern (arity
2-4/2-10/2-8 respectively) for the remaining bit-string types: AB
(BYTE), AD (DWORD), AL (LWORD), AQ (QUARTER), AW (WORD). FBT only —
C++ to follow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add generic bitwise AND, OR, and XOR function blocks for additional bit-string adapter types to extend the booleanOperators typelib.

New Features:
- Introduce AB (BYTE) adapter function blocks for AND (2–4 inputs), OR (2–10 inputs), and XOR (2–8 inputs).
- Introduce AD (DWORD) adapter function blocks for AND (2–4 inputs), OR (2–10 inputs), and XOR (2–8 inputs).
- Introduce AL (LWORD) adapter function blocks for AND (2–4 inputs), OR (2–10 inputs), and XOR (2–8 inputs).
- Introduce AQ (QUARTER) adapter function blocks for AND (2–4 inputs), OR (2–10 inputs), and XOR (2–8 inputs).
- Introduce AW (WORD) adapter function blocks for AND (2–4 inputs), OR (2–10 inputs), and XOR (2–8 inputs).