### PR TITLE
Add per-time events and Composite adapter wrappers for the timed sequences

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06.fbt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FBType Name="AnlagenSequenz_06" Comment="Ring aus getrennter Vorlauf- und Nachlauf-Kette (je 5 Zwischenschritte) für 6 Motoren mit Störungs-Kaskade, s. KONZEPT_Anlagensequenz.md">
-	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;DRAFT (2026-08-12), 2. Fassung: Vorlauf und Nachlauf sind jetzt zwei getrennte,  &#10;jeweils rein lineare Ketten (S_VOR1..S_VOR5 bzw. S_NACH1..S_NACH5), verbunden  &#10;über S_AUS (unten) und S_LAEUFT (oben) zu einem Ring - anstelle der ersten  &#10;Fassung mit 7 bidirektional genutzten Zuständen. Jeder Zustand hat dadurch genau  &#10;einen festen Zeitwert (ZEk_EIN bzw. ZEk_AUS) und ein festes Motor-Muster, keine  &#10;Richtungs-Fallunterscheidung mehr pro Zustand nötig.  &#10; &#10;Bekannte, bewusste Vereinfachungen:  &#10;1) Jede STOERUNG_Mx hat ein eigenes Event EI_Mx (analog EO_Mx/DO_Mx), das direkt  &#10;   von jedem Zustand vor dem jeweiligen Zielschritt (S_NACH_x, bzw. S_AUS bei  &#10;   x=6) dorthin springt - kein Umweg mehr über einen Spiegelpunkt und kein  &#10;   Nachfassen über mehrere Zyklen. Ein AUS-Abbruch aus dem Vorlauf springt  &#10;   weiterhin auf den Spiegelpunkt (S_VOR_k -&gt; S_NACH_(6-k)), da dort keine  &#10;   Motoren-Störung, sondern nur der Bedienerwunsch vorliegt.  &#10;2) Pro Motor gibt es ein Event EO_Mx mit angehängtem DO_Mx (analog EO_Sx/DO_Sx in  &#10;   sequence_T_04/_08). Der Baustein hat keine Selbstschleifen mehr (alle bisherigen  &#10;   liefen über das inzwischen entfernte EI_CYCLIC) - EO_Mx feuert also nur noch bei  &#10;   einem echten Zustandswechsel.  &#10;3) MaxBetriebRest/Nachlauf-Reste (Demo-Server-Schema) sind noch nicht abgebildet.">
+	<Identification Standard="61499-2" ApplicationDomain="Fördertechnik" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0  &#10; &#10;DRAFT (2026-08-12), 2. Fassung: Vorlauf und Nachlauf sind jetzt zwei getrennte,  &#10;jeweils rein lineare Ketten (S_VOR1..S_VOR5 bzw. S_NACH1..S_NACH5), verbunden  &#10;über S_AUS (unten) und S_LAEUFT (oben) zu einem Ring - anstelle der ersten  &#10;Fassung mit 7 bidirektional genutzten Zuständen. Jeder Zustand hat dadurch genau  &#10;einen festen Zeitwert (ZEk_EIN bzw. ZEk_AUS) und ein festes Motor-Muster, keine  &#10;Richtungs-Fallunterscheidung mehr pro Zustand nötig.  &#10; &#10;Bekannte, bewusste Vereinfachungen:  &#10;1) Jede STOERUNG_Mx hat ein eigenes Event EI_Mx (analog EO_Mx/DO_Mx), das direkt  &#10;   von jedem Zustand vor dem jeweiligen Zielschritt (S_NACH_x, bzw. S_AUS bei  &#10;   x=6) dorthin springt - kein Umweg mehr über einen Spiegelpunkt und kein  &#10;   Nachfassen über mehrere Zyklen. Ein AUS-Abbruch aus dem Vorlauf springt  &#10;   weiterhin auf den Spiegelpunkt (S_VOR_k -&gt; S_NACH_(6-k)), da dort keine  &#10;   Motoren-Störung, sondern nur der Bedienerwunsch vorliegt.  &#10;2) Pro Motor gibt es ein Event EO_Mx mit angehängtem DO_Mx (analog EO_Sx/DO_Sx in  &#10;   sequence_T_04/_08). Der Baustein hat keine Selbstschleifen mehr (alle bisherigen  &#10;   liefen über das inzwischen entfernte EI_CYCLIC) - EO_Mx feuert also nur noch bei  &#10;   einem echten Zustandswechsel.  &#10;3) MaxBetriebRest/Nachlauf-Reste (Demo-Server-Schema) sind noch nicht abgebildet.">
 	</Identification>
 	<VersionInfo Organization="HR Agrartechnik GmbH" Version="0.6" Author="Franz Höpfinger" Date="2026-08-12">
 	</VersionInfo>
@@ -20,6 +20,36 @@
 			<Event Name="EIN" Type="Event" Comment="Startsequenz auslösen; nur wirksam wenn EINSCHALTBEREIT=TRUE; quittiert dabei zugleich eine anstehende Störungsanzeige">
 			</Event>
 			<Event Name="AUS" Type="Event" Comment="Stopsequenz auslösen, aus jedem Schritt der Vorlauf-Kette oder aus S_LAEUFT">
+			</Event>
+			<Event Name="SET_ZE1_EIN" Type="Event" Comment="Update ZE1_EIN independently of EIN">
+				<With Var="ZE1_EIN"/>
+			</Event>
+			<Event Name="SET_ZE2_EIN" Type="Event" Comment="Update ZE2_EIN independently of EIN">
+				<With Var="ZE2_EIN"/>
+			</Event>
+			<Event Name="SET_ZE3_EIN" Type="Event" Comment="Update ZE3_EIN independently of EIN">
+				<With Var="ZE3_EIN"/>
+			</Event>
+			<Event Name="SET_ZE4_EIN" Type="Event" Comment="Update ZE4_EIN independently of EIN">
+				<With Var="ZE4_EIN"/>
+			</Event>
+			<Event Name="SET_ZE5_EIN" Type="Event" Comment="Update ZE5_EIN independently of EIN">
+				<With Var="ZE5_EIN"/>
+			</Event>
+			<Event Name="SET_ZE1_AUS" Type="Event" Comment="Update ZE1_AUS independently of AUS">
+				<With Var="ZE1_AUS"/>
+			</Event>
+			<Event Name="SET_ZE2_AUS" Type="Event" Comment="Update ZE2_AUS independently of AUS">
+				<With Var="ZE2_AUS"/>
+			</Event>
+			<Event Name="SET_ZE3_AUS" Type="Event" Comment="Update ZE3_AUS independently of AUS">
+				<With Var="ZE3_AUS"/>
+			</Event>
+			<Event Name="SET_ZE4_AUS" Type="Event" Comment="Update ZE4_AUS independently of AUS">
+				<With Var="ZE4_AUS"/>
+			</Event>
+			<Event Name="SET_ZE5_AUS" Type="Event" Comment="Update ZE5_AUS independently of AUS">
+				<With Var="ZE5_AUS"/>
 			</Event>
 			<Event Name="EI_M1" Type="Event" Comment="Störungsstatus Motor 1 hat sich geändert">
 				<With Var="STOERUNG_M1"/>
@@ -315,6 +345,16 @@
 			<ECTransition Source="sNACH4" Destination="sAUS" Condition="EI_M6[STOERUNG_M6]" Comment="" x="4666.67" y="8960"/>
 			<ECTransition Source="sNACH5" Destination="sAUS" Condition="timeOut.TimeOut" Comment="" x="5540" y="8853.33"/>
 			<ECTransition Source="sNACH5" Destination="sAUS" Condition="EI_M6[STOERUNG_M6]" Comment="" x="4666.67" y="9226.67"/>
+			<ECTransition Source="sVOR1" Destination="sVOR1" Condition="SET_ZE1_EIN" Comment="Live-Update: laeuft timeOut mit ZE1_EIN gerade, S_VOR1_Setup neu ausfuehren"/>
+			<ECTransition Source="sVOR2" Destination="sVOR2" Condition="SET_ZE2_EIN" Comment="Live-Update: laeuft timeOut mit ZE2_EIN gerade, S_VOR2_Setup neu ausfuehren"/>
+			<ECTransition Source="sVOR3" Destination="sVOR3" Condition="SET_ZE3_EIN" Comment="Live-Update: laeuft timeOut mit ZE3_EIN gerade, S_VOR3_Setup neu ausfuehren"/>
+			<ECTransition Source="sVOR4" Destination="sVOR4" Condition="SET_ZE4_EIN" Comment="Live-Update: laeuft timeOut mit ZE4_EIN gerade, S_VOR4_Setup neu ausfuehren"/>
+			<ECTransition Source="sVOR5" Destination="sVOR5" Condition="SET_ZE5_EIN" Comment="Live-Update: laeuft timeOut mit ZE5_EIN gerade, S_VOR5_Setup neu ausfuehren"/>
+			<ECTransition Source="sNACH1" Destination="sNACH1" Condition="SET_ZE1_AUS" Comment="Live-Update: laeuft timeOut mit ZE1_AUS gerade, S_NACH1_Setup neu ausfuehren"/>
+			<ECTransition Source="sNACH2" Destination="sNACH2" Condition="SET_ZE2_AUS" Comment="Live-Update: laeuft timeOut mit ZE2_AUS gerade, S_NACH2_Setup neu ausfuehren"/>
+			<ECTransition Source="sNACH3" Destination="sNACH3" Condition="SET_ZE3_AUS" Comment="Live-Update: laeuft timeOut mit ZE3_AUS gerade, S_NACH3_Setup neu ausfuehren"/>
+			<ECTransition Source="sNACH4" Destination="sNACH4" Condition="SET_ZE4_AUS" Comment="Live-Update: laeuft timeOut mit ZE4_AUS gerade, S_NACH4_Setup neu ausfuehren"/>
+			<ECTransition Source="sNACH5" Destination="sNACH5" Condition="SET_ZE5_AUS" Comment="Live-Update: laeuft timeOut mit ZE5_AUS gerade, S_NACH5_Setup neu ausfuehren"/>
 		</ECC>
 		<Algorithm Name="EI_CYCLIC_Auswertung" Comment="Liest STOERUNG_M1..M6 neu ein, setzt STATUS_STOERUNG falls eine aktiv ist, und berechnet&#10;EINSCHALTBEREIT">
 			<ST><![CDATA[

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06_ADAPTER.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06_ADAPTER.fbt
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="AnlagenSequenz_06_ADAPTER" Comment="Composite wrapper around AnlagenSequenz_06: DO_Mx/STOERUNG_Mx (Event+BOOL) bundled into AX adapters, ZE*_EIN/AUS each fed via its own ATM adapter socket. timeOut stays internal, not exposed.">
+	<Identification Standard="61499-2" ApplicationDomain="Fördertechnik" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-14" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::utils::sequence::timed">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="EIN" Type="Event" Comment="Startsequenz auslösen; nur wirksam wenn EINSCHALTBEREIT=TRUE; quittiert dabei zugleich eine anstehende Störungsanzeige">
+			</Event>
+			<Event Name="AUS" Type="Event" Comment="Stopsequenz auslösen, aus jedem Schritt der Vorlauf-Kette oder aus S_LAEUFT">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Ausführungsbestätigung, mit jedem Zustands-Update">
+				<With Var="STATUS_BETRIEB"/>
+				<With Var="STATUS_STOERUNG"/>
+				<With Var="ZAEHLSTAND"/>
+				<With Var="EINSCHALTBEREIT"/>
+			</Event>
+		</EventOutputs>
+		<OutputVars>
+			<VarDeclaration Name="STATUS_BETRIEB" Type="SINT" Comment="0=Aus 1=Hochfahren 2=Läuft 3=Herunterfahren"/>
+			<VarDeclaration Name="STATUS_STOERUNG" Type="SINT" Comment="0=keine 4=aktiv, verriegelt bis EIN"/>
+			<VarDeclaration Name="EINSCHALTBEREIT" Type="BOOL" Comment="TRUE nur wenn alle Motoren stehen UND alle Motoren störungsfrei sind"/>
+			<VarDeclaration Name="ZAEHLSTAND" Type="SINT" Comment="0..6, Anzahl aktuell laufender Motoren"/>
+		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="DO_M1" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 1" x="5793.33" y="3246.67"/>
+			<AdapterDeclaration Name="DO_M2" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 2" x="5726.67" y="4040"/>
+			<AdapterDeclaration Name="DO_M3" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 3" x="5593.33" y="4833.33"/>
+			<AdapterDeclaration Name="DO_M4" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 4" x="5460" y="5626.67"/>
+			<AdapterDeclaration Name="DO_M5" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 5" x="5326.67" y="6420"/>
+			<AdapterDeclaration Name="DO_M6" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 6" x="5193.33" y="7213.33"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="ATM_ZE1_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR1 zu S_VOR2, M5 startet (Vorlauf)" x="673.33" y="-786.67"/>
+			<AdapterDeclaration Name="ATM_ZE2_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR2 zu S_VOR3, M4 startet (Vorlauf)" x="673.33" y="6.67"/>
+			<AdapterDeclaration Name="ATM_ZE3_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR3 zu S_VOR4, M3 startet (Vorlauf)" x="673.33" y="800"/>
+			<AdapterDeclaration Name="ATM_ZE4_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR4 zu S_VOR5, M2 startet (Vorlauf)" x="1366.67" y="1400"/>
+			<AdapterDeclaration Name="ATM_ZE5_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR5 zu S_LAEUFT, M1 startet (Vorlauf)" x="1366.67" y="2193.33"/>
+			<AdapterDeclaration Name="ATM_ZE1_AUS" Type="adapter::types::unidirectional::ATM" Comment="S_NACH1 zu S_NACH2, M2 stoppt (Nachlauf)" x="1433.33" y="2793.33"/>
+			<AdapterDeclaration Name="ATM_ZE2_AUS" Type="adapter::types::unidirectional::ATM" Comment="S_NACH2 zu S_NACH3, M3 stoppt (Nachlauf)" x="1566.67" y="4180"/>
+			<AdapterDeclaration Name="ATM_ZE3_AUS" Type="adapter::types::unidirectional::ATM" Comment="S_NACH3 zu S_NACH4, M4 stoppt (Nachlauf)" x="1700" y="4880"/>
+			<AdapterDeclaration Name="ATM_ZE4_AUS" Type="adapter::types::unidirectional::ATM" Comment="S_NACH4 zu S_NACH5, M5 stoppt (Nachlauf)" x="1700" y="5673.33"/>
+			<AdapterDeclaration Name="ATM_ZE5_AUS" Type="adapter::types::unidirectional::ATM" Comment="S_NACH5 zu S_AUS, M6 stoppt (Nachlauf)" x="1766.67" y="6466.67"/>
+			<AdapterDeclaration Name="STOERUNG_M1" Type="adapter::types::unidirectional::AX" Comment="Motor 1 hat aktuell eine Störung anstehen" x="1766.67" y="7260"/>
+			<AdapterDeclaration Name="STOERUNG_M2" Type="adapter::types::unidirectional::AX" Comment="Motor 2 hat aktuell eine Störung anstehen" x="673.33" y="6066.67"/>
+			<AdapterDeclaration Name="STOERUNG_M3" Type="adapter::types::unidirectional::AX" Comment="Motor 3 hat aktuell eine Störung anstehen" x="673.33" y="6860"/>
+			<AdapterDeclaration Name="STOERUNG_M4" Type="adapter::types::unidirectional::AX" Comment="Motor 4 hat aktuell eine Störung anstehen" x="673.33" y="7653.33"/>
+			<AdapterDeclaration Name="STOERUNG_M5" Type="adapter::types::unidirectional::AX" Comment="Motor 5 hat aktuell eine Störung anstehen" x="673.33" y="8446.67"/>
+			<AdapterDeclaration Name="STOERUNG_M6" Type="adapter::types::unidirectional::AX" Comment="Motor 6 hat aktuell eine Störung anstehen" x="673.33" y="9240"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="Sequence" Type="logiBUS::utils::sequence::timed::AnlagenSequenz_06" x="3600" y="1900">
+		</FB>
+		<FB Name="E_TimeOut" Type="iec61499::events::E_TimeOut" x="4993.33" y="8033.33">
+		</FB>
+		<EventConnections>
+			<Connection Source="EIN" Destination="Sequence.EIN" dx1="2626.67"/>
+			<Connection Source="AUS" Destination="Sequence.AUS" dx1="2560"/>
+			<Connection Source="ATM_ZE1_EIN.E1" Destination="Sequence.SET_ZE1_EIN" dx1="2160"/>
+			<Connection Source="ATM_ZE2_EIN.E1" Destination="Sequence.SET_ZE2_EIN" dx1="2026.67"/>
+			<Connection Source="ATM_ZE3_EIN.E1" Destination="Sequence.SET_ZE3_EIN" dx1="1893.33"/>
+			<Connection Source="ATM_ZE4_EIN.E1" Destination="Sequence.SET_ZE4_EIN" dx1="1000"/>
+			<Connection Source="ATM_ZE5_EIN.E1" Destination="Sequence.SET_ZE5_EIN" dx1="866.67"/>
+			<Connection Source="ATM_ZE1_AUS.E1" Destination="Sequence.SET_ZE1_AUS" dx1="66.67"/>
+			<Connection Source="ATM_ZE2_AUS.E1" Destination="Sequence.SET_ZE2_AUS" dx1="66.67"/>
+			<Connection Source="ATM_ZE3_AUS.E1" Destination="Sequence.SET_ZE3_AUS" dx1="66.67"/>
+			<Connection Source="ATM_ZE4_AUS.E1" Destination="Sequence.SET_ZE4_AUS" dx1="200"/>
+			<Connection Source="ATM_ZE5_AUS.E1" Destination="Sequence.SET_ZE5_AUS" dx1="266.67"/>
+			<Connection Source="STOERUNG_M1.E1" Destination="Sequence.EI_M1" dx1="466.67"/>
+			<Connection Source="STOERUNG_M2.E1" Destination="Sequence.EI_M2" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M3.E1" Destination="Sequence.EI_M3" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M4.E1" Destination="Sequence.EI_M4" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M5.E1" Destination="Sequence.EI_M5" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M6.E1" Destination="Sequence.EI_M6" dx1="1233.33"/>
+			<Connection Source="Sequence.CNF" Destination="CNF" dx1="66.67"/>
+			<Connection Source="Sequence.EO_M1" Destination="DO_M1.E1" dx1="866.67"/>
+			<Connection Source="Sequence.EO_M2" Destination="DO_M2.E1" dx1="800"/>
+			<Connection Source="Sequence.EO_M3" Destination="DO_M3.E1" dx1="666.67"/>
+			<Connection Source="Sequence.EO_M4" Destination="DO_M4.E1" dx1="533.33"/>
+			<Connection Source="Sequence.EO_M5" Destination="DO_M5.E1" dx1="400"/>
+			<Connection Source="Sequence.EO_M6" Destination="DO_M6.E1" dx1="266.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="ATM_ZE1_EIN.D1" Destination="Sequence.ZE1_EIN" dx1="2093.33"/>
+			<Connection Source="ATM_ZE2_EIN.D1" Destination="Sequence.ZE2_EIN" dx1="1960"/>
+			<Connection Source="ATM_ZE3_EIN.D1" Destination="Sequence.ZE3_EIN" dx1="1826.67"/>
+			<Connection Source="ATM_ZE4_EIN.D1" Destination="Sequence.ZE4_EIN" dx1="933.33"/>
+			<Connection Source="ATM_ZE5_EIN.D1" Destination="Sequence.ZE5_EIN" dx1="800"/>
+			<Connection Source="ATM_ZE1_AUS.D1" Destination="Sequence.ZE1_AUS" dx1="533.33"/>
+			<Connection Source="ATM_ZE2_AUS.D1" Destination="Sequence.ZE2_AUS" dx1="66.67"/>
+			<Connection Source="ATM_ZE3_AUS.D1" Destination="Sequence.ZE3_AUS" dx1="266.67"/>
+			<Connection Source="ATM_ZE4_AUS.D1" Destination="Sequence.ZE4_AUS" dx1="400"/>
+			<Connection Source="ATM_ZE5_AUS.D1" Destination="Sequence.ZE5_AUS" dx1="533.33"/>
+			<Connection Source="STOERUNG_M1.D1" Destination="Sequence.STOERUNG_M1" dx1="600"/>
+			<Connection Source="STOERUNG_M2.D1" Destination="Sequence.STOERUNG_M2" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M3.D1" Destination="Sequence.STOERUNG_M3" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M4.D1" Destination="Sequence.STOERUNG_M4" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M5.D1" Destination="Sequence.STOERUNG_M5" dx1="1233.33"/>
+			<Connection Source="STOERUNG_M6.D1" Destination="Sequence.STOERUNG_M6" dx1="2026.67"/>
+			<Connection Source="Sequence.STATUS_BETRIEB" Destination="STATUS_BETRIEB" dx1="133.33"/>
+			<Connection Source="Sequence.STATUS_STOERUNG" Destination="STATUS_STOERUNG" dx1="333.33"/>
+			<Connection Source="Sequence.ZAEHLSTAND" Destination="ZAEHLSTAND" dx1="600"/>
+			<Connection Source="Sequence.EINSCHALTBEREIT" Destination="EINSCHALTBEREIT" dx1="466.67"/>
+			<Connection Source="Sequence.DO_M1" Destination="DO_M1.D1" dx1="733.33"/>
+			<Connection Source="Sequence.DO_M2" Destination="DO_M2.D1" dx1="800"/>
+			<Connection Source="Sequence.DO_M3" Destination="DO_M3.D1" dx1="466.67"/>
+			<Connection Source="Sequence.DO_M4" Destination="DO_M4.D1" dx1="333.33"/>
+			<Connection Source="Sequence.DO_M5" Destination="DO_M5.D1" dx1="200"/>
+			<Connection Source="Sequence.DO_M6" Destination="DO_M6.D1" dx1="133.33"/>
+		</DataConnections>
+		<AdapterConnections>
+			<Connection Source="Sequence.timeOut" Destination="E_TimeOut.TimeOutSocket" dx1="66.67"/>
+		</AdapterConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/sequence_T_08.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/sequence_T_08.fbt
@@ -22,6 +22,30 @@
 			</Event>
 			<Event Name="RESET" Type="Event" Comment="Reset from any State to START">
 			</Event>
+			<Event Name="SET_DT_S1_S2" Type="Event" Comment="Update DT_S1_S2 independently of START_S1">
+				<With Var="DT_S1_S2"/>
+			</Event>
+			<Event Name="SET_DT_S2_S3" Type="Event" Comment="Update DT_S2_S3 independently of START_S1">
+				<With Var="DT_S2_S3"/>
+			</Event>
+			<Event Name="SET_DT_S3_S4" Type="Event" Comment="Update DT_S3_S4 independently of START_S1">
+				<With Var="DT_S3_S4"/>
+			</Event>
+			<Event Name="SET_DT_S4_S5" Type="Event" Comment="Update DT_S4_S5 independently of START_S1">
+				<With Var="DT_S4_S5"/>
+			</Event>
+			<Event Name="SET_DT_S5_S6" Type="Event" Comment="Update DT_S5_S6 independently of START_S1">
+				<With Var="DT_S5_S6"/>
+			</Event>
+			<Event Name="SET_DT_S6_S7" Type="Event" Comment="Update DT_S6_S7 independently of START_S1">
+				<With Var="DT_S6_S7"/>
+			</Event>
+			<Event Name="SET_DT_S7_S8" Type="Event" Comment="Update DT_S7_S8 independently of START_S1">
+				<With Var="DT_S7_S8"/>
+			</Event>
+			<Event Name="SET_DT_S8_START" Type="Event" Comment="Update DT_S8_START independently of START_S1">
+				<With Var="DT_S8_START"/>
+			</Event>
 		</EventInputs>
 		<EventOutputs>
 			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
@@ -146,25 +170,33 @@
 				<ECAction Algorithm="State_07_X" Output="EO_S7"/>
 				<ECAction Algorithm="State_08_X" Output="EO_S8"/>
 			</ECState>
-			<ECTransition Source="sState_01" Destination="sState_02" Condition="timeOut.TimeOut" x="2866.67" y="1680"/>
-			<ECTransition Source="sState_02" Destination="sState_03" Condition="timeOut.TimeOut" x="2893.33" y="2360"/>
-			<ECTransition Source="sState_03" Destination="sState_04" Condition="timeOut.TimeOut" x="2880" y="3053.33"/>
-			<ECTransition Source="sState_00" Destination="sState_01" Condition="START_S1" x="1126.67" y="3293.33"/>
-			<ECTransition Source="xSTART" Destination="sState_01" Condition="START_S1" x="2213.33" y="846.67"/>
-			<ECTransition Source="sState_01" Destination="sRESET" Condition="RESET" x="-73.33" y="1653.33"/>
-			<ECTransition Source="sState_02" Destination="sRESET" Condition="RESET" x="60" y="2260"/>
-			<ECTransition Source="sState_03" Destination="sRESET" Condition="RESET" x="133.33" y="2873.33"/>
-			<ECTransition Source="sState_04" Destination="sState_05" Condition="timeOut.TimeOut" x="2866.67" y="3706.67"/>
-			<ECTransition Source="sState_04" Destination="sRESET" Condition="RESET" x="340" y="3406.67"/>
-			<ECTransition Source="sState_05" Destination="sState_06" Condition="timeOut.TimeOut" x="2860" y="4406.67"/>
-			<ECTransition Source="sState_05" Destination="sRESET" Condition="RESET" x="353.33" y="4120"/>
-			<ECTransition Source="sRESET" Destination="sState_00" Condition="1" x="-100" y="7620"/>
-			<ECTransition Source="sState_07" Destination="sState_08" Condition="timeOut.TimeOut" x="2880" y="5700"/>
-			<ECTransition Source="sState_07" Destination="sRESET" Condition="RESET" x="340" y="5320"/>
-			<ECTransition Source="sState_06" Destination="sState_07" Condition="timeOut.TimeOut" x="2866.67" y="5066.67"/>
-			<ECTransition Source="sState_08" Destination="sState_00" Condition="timeOut.TimeOut" x="2886.67" y="6380"/>
-			<ECTransition Source="sState_08" Destination="sRESET" Condition="RESET" x="460" y="5766.67"/>
-			<ECTransition Source="sState_06" Destination="sRESET" Condition="RESET" x="413.33" y="4706.67"/>
+			<ECTransition Source="sState_01" Destination="sState_02" Condition="timeOut.TimeOut" Comment="" x="2866.67" y="1680"/>
+			<ECTransition Source="sState_02" Destination="sState_03" Condition="timeOut.TimeOut" Comment="" x="2893.33" y="2360"/>
+			<ECTransition Source="sState_03" Destination="sState_04" Condition="timeOut.TimeOut" Comment="" x="2880" y="3053.33"/>
+			<ECTransition Source="sState_00" Destination="sState_01" Condition="START_S1" Comment="" x="1126.67" y="3293.33"/>
+			<ECTransition Source="xSTART" Destination="sState_01" Condition="START_S1" Comment="" x="2213.33" y="846.67"/>
+			<ECTransition Source="sState_01" Destination="sRESET" Condition="RESET" Comment="" x="-73.33" y="1653.33"/>
+			<ECTransition Source="sState_02" Destination="sRESET" Condition="RESET" Comment="" x="60" y="2260"/>
+			<ECTransition Source="sState_03" Destination="sRESET" Condition="RESET" Comment="" x="133.33" y="2873.33"/>
+			<ECTransition Source="sState_04" Destination="sState_05" Condition="timeOut.TimeOut" Comment="" x="2866.67" y="3706.67"/>
+			<ECTransition Source="sState_04" Destination="sRESET" Condition="RESET" Comment="" x="340" y="3406.67"/>
+			<ECTransition Source="sState_05" Destination="sState_06" Condition="timeOut.TimeOut" Comment="" x="2860" y="4406.67"/>
+			<ECTransition Source="sState_05" Destination="sRESET" Condition="RESET" Comment="" x="353.33" y="4120"/>
+			<ECTransition Source="sRESET" Destination="sState_00" Condition="1" Comment="" x="-100" y="7620"/>
+			<ECTransition Source="sState_07" Destination="sState_08" Condition="timeOut.TimeOut" Comment="" x="2880" y="5700"/>
+			<ECTransition Source="sState_07" Destination="sRESET" Condition="RESET" Comment="" x="340" y="5320"/>
+			<ECTransition Source="sState_06" Destination="sState_07" Condition="timeOut.TimeOut" Comment="" x="2866.67" y="5066.67"/>
+			<ECTransition Source="sState_08" Destination="sState_00" Condition="timeOut.TimeOut" Comment="" x="2886.67" y="6380"/>
+			<ECTransition Source="sState_08" Destination="sRESET" Condition="RESET" Comment="" x="460" y="5766.67"/>
+			<ECTransition Source="sState_06" Destination="sRESET" Condition="RESET" Comment="" x="413.33" y="4706.67"/>
+			<ECTransition Source="sState_01" Destination="sState_01" Condition="SET_DT_S1_S2" Comment="Live-Update: laeuft timeOut mit DT_S1_S2 gerade, State_01_C neu ausfuehren"/>
+			<ECTransition Source="sState_02" Destination="sState_02" Condition="SET_DT_S2_S3" Comment="Live-Update: laeuft timeOut mit DT_S2_S3 gerade, State_02_C neu ausfuehren"/>
+			<ECTransition Source="sState_03" Destination="sState_03" Condition="SET_DT_S3_S4" Comment="Live-Update: laeuft timeOut mit DT_S3_S4 gerade, State_03_C neu ausfuehren"/>
+			<ECTransition Source="sState_04" Destination="sState_04" Condition="SET_DT_S4_S5" Comment="Live-Update: laeuft timeOut mit DT_S4_S5 gerade, State_04_C neu ausfuehren"/>
+			<ECTransition Source="sState_05" Destination="sState_05" Condition="SET_DT_S5_S6" Comment="Live-Update: laeuft timeOut mit DT_S5_S6 gerade, State_05_C neu ausfuehren"/>
+			<ECTransition Source="sState_06" Destination="sState_06" Condition="SET_DT_S6_S7" Comment="Live-Update: laeuft timeOut mit DT_S6_S7 gerade, State_06_C neu ausfuehren"/>
+			<ECTransition Source="sState_07" Destination="sState_07" Condition="SET_DT_S7_S8" Comment="Live-Update: laeuft timeOut mit DT_S7_S8 gerade, State_07_C neu ausfuehren"/>
+			<ECTransition Source="sState_08" Destination="sState_08" Condition="SET_DT_S8_START" Comment="Live-Update: laeuft timeOut mit DT_S8_START gerade, State_08_C neu ausfuehren"/>
 		</ECC>
 		<Algorithm Name="State_00_C">
 			<ST><![CDATA[ // State_00 Confirmation Step

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/sequence_T_08_ADAPTER.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/sequence_T_08_ADAPTER.fbt
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="sequence_T_08_ADAPTER" Comment="Composite wrapper around sequence_T_08: Event/BOOL outputs bundled into AX/AS adapters, DT_Sx_Sy times each fed via its own ATM adapter socket. timeOut stays internal, not exposed.">
+	<Identification Standard="61499-2" Description="Copyright (c) 2026 HR Agrartechnik GmbH  &#10; &#10;This program and the accompanying materials are made  &#10;available under the terms of the Eclipse Public License 2.0  &#10;which is available at https://www.eclipse.org/legal/epl-2.0/  &#10; &#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="1.0" Author="Franz Höpfinger" Date="2026-08-14" Remarks="initial API and implementation">
+	</VersionInfo>
+	<CompilerInfo packageName="logiBUS::utils::sequence::timed">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="START_S1" Type="Event" Comment="jump from START to State_01">
+			</Event>
+			<Event Name="RESET" Type="Event" Comment="Reset from any State to START">
+			</Event>
+		</EventInputs>
+		<Plugs>
+			<AdapterDeclaration Name="STATE_NR" Type="adapter::types::unidirectional::AS" Comment="State Number Adapter" x="3773.33" y="-446.67"/>
+			<AdapterDeclaration Name="DO_S1" Type="adapter::types::unidirectional::AX" Comment="Output if State_01 is active" x="3906.67" y="346.67"/>
+			<AdapterDeclaration Name="DO_S2" Type="adapter::types::unidirectional::AX" Comment="Output if State_02 is active" x="4040" y="1140"/>
+			<AdapterDeclaration Name="DO_S3" Type="adapter::types::unidirectional::AX" Comment="Output if State_03 is active" x="4173.33" y="1933.33"/>
+			<AdapterDeclaration Name="DO_S4" Type="adapter::types::unidirectional::AX" Comment="Output if State_04 is active" x="4306.67" y="2726.67"/>
+			<AdapterDeclaration Name="DO_S5" Type="adapter::types::unidirectional::AX" Comment="Output if State_05 is active" x="4506.67" y="3520"/>
+			<AdapterDeclaration Name="DO_S6" Type="adapter::types::unidirectional::AX" Comment="Output if State_06 is active" x="4506.67" y="4313.33"/>
+			<AdapterDeclaration Name="DO_S7" Type="adapter::types::unidirectional::AX" Comment="Output if State_07 is active" x="4373.33" y="5106.67"/>
+			<AdapterDeclaration Name="DO_S8" Type="adapter::types::unidirectional::AX" Comment="Output if State_08 is active" x="4240" y="5900"/>
+		</Plugs>
+		<Sockets>
+			<AdapterDeclaration Name="ATM_S1_S2" Type="adapter::types::unidirectional::ATM" Comment="State_01 to State_02 timed" x="1100" y="2300"/>
+			<AdapterDeclaration Name="ATM_S2_S3" Type="adapter::types::unidirectional::ATM" Comment="State_02 to State_03 timed" x="1100" y="3093.33"/>
+			<AdapterDeclaration Name="ATM_S3_S4" Type="adapter::types::unidirectional::ATM" Comment="State_03 to State_04 timed" x="1100" y="3886.67"/>
+			<AdapterDeclaration Name="ATM_S4_S5" Type="adapter::types::unidirectional::ATM" Comment="State_04 to State_05 timed" x="1100" y="4680"/>
+			<AdapterDeclaration Name="ATM_S5_S6" Type="adapter::types::unidirectional::ATM" Comment="State_05 to State_06 timed" x="1100" y="5473.33"/>
+			<AdapterDeclaration Name="ATM_S6_S7" Type="adapter::types::unidirectional::ATM" Comment="State_06 to State_07 timed" x="1100" y="6266.67"/>
+			<AdapterDeclaration Name="ATM_S7_S8" Type="adapter::types::unidirectional::ATM" Comment="State_07 to State_08 timed" x="1100" y="7060"/>
+			<AdapterDeclaration Name="ATM_S8_START" Type="adapter::types::unidirectional::ATM" Comment="State_08 to START timed" x="1100" y="7853.33"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="Sequence" Type="logiBUS::utils::sequence::timed::sequence_T_08" x="2500" y="3000">
+		</FB>
+		<FB Name="E_TimeOut" Type="iec61499::events::E_TimeOut" x="4300" y="6500">
+		</FB>
+		<EventConnections>
+			<Connection Source="START_S1" Destination="Sequence.START_S1" dx1="4293.33"/>
+			<Connection Source="RESET" Destination="Sequence.RESET" dx1="4260"/>
+			<Connection Source="ATM_S1_S2.E1" Destination="Sequence.SET_DT_S1_S2" dx1="453.33"/>
+			<Connection Source="ATM_S2_S3.E1" Destination="Sequence.SET_DT_S2_S3" dx1="420"/>
+			<Connection Source="ATM_S3_S4.E1" Destination="Sequence.SET_DT_S3_S4" dx1="360"/>
+			<Connection Source="ATM_S4_S5.E1" Destination="Sequence.SET_DT_S4_S5" dx1="393.33"/>
+			<Connection Source="ATM_S5_S6.E1" Destination="Sequence.SET_DT_S5_S6" dx1="426.67"/>
+			<Connection Source="ATM_S6_S7.E1" Destination="Sequence.SET_DT_S6_S7" dx1="460"/>
+			<Connection Source="ATM_S7_S8.E1" Destination="Sequence.SET_DT_S7_S8" dx1="493.33"/>
+			<Connection Source="ATM_S8_START.E1" Destination="Sequence.SET_DT_S8_START" dx1="386.67"/>
+			<Connection Source="Sequence.CNF" Destination="STATE_NR.E1" dx1="86.67"/>
+			<Connection Source="Sequence.EO_S1" Destination="DO_S1.E1" dx1="153.33"/>
+			<Connection Source="Sequence.EO_S2" Destination="DO_S2.E1" dx1="240"/>
+			<Connection Source="Sequence.EO_S3" Destination="DO_S3.E1" dx1="400"/>
+			<Connection Source="Sequence.EO_S4" Destination="DO_S4.E1" dx1="466.67"/>
+			<Connection Source="Sequence.EO_S5" Destination="DO_S5.E1" dx1="533.33"/>
+			<Connection Source="Sequence.EO_S6" Destination="DO_S6.E1" dx1="333.33"/>
+			<Connection Source="Sequence.EO_S7" Destination="DO_S7.E1" dx1="300"/>
+			<Connection Source="Sequence.EO_S8" Destination="DO_S8.E1" dx1="233.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="ATM_S1_S2.D1" Destination="Sequence.DT_S1_S2" dx1="326.67"/>
+			<Connection Source="ATM_S2_S3.D1" Destination="Sequence.DT_S2_S3" dx1="293.33"/>
+			<Connection Source="ATM_S3_S4.D1" Destination="Sequence.DT_S3_S4" dx1="260"/>
+			<Connection Source="ATM_S4_S5.D1" Destination="Sequence.DT_S4_S5" dx1="560"/>
+			<Connection Source="ATM_S5_S6.D1" Destination="Sequence.DT_S5_S6" dx1="593.33"/>
+			<Connection Source="ATM_S6_S7.D1" Destination="Sequence.DT_S6_S7" dx1="626.67"/>
+			<Connection Source="ATM_S7_S8.D1" Destination="Sequence.DT_S7_S8" dx1="660"/>
+			<Connection Source="ATM_S8_START.D1" Destination="Sequence.DT_S8_START" dx1="553.33"/>
+			<Connection Source="Sequence.STATE_NR" Destination="STATE_NR.D1" dx1="120"/>
+			<Connection Source="Sequence.DO_S1" Destination="DO_S1.D1" dx1="186.67"/>
+			<Connection Source="Sequence.DO_S2" Destination="DO_S2.D1" dx1="366.67"/>
+			<Connection Source="Sequence.DO_S3" Destination="DO_S3.D1" dx1="433.33"/>
+			<Connection Source="Sequence.DO_S4" Destination="DO_S4.D1" dx1="500"/>
+			<Connection Source="Sequence.DO_S5" Destination="DO_S5.D1" dx1="533.33"/>
+			<Connection Source="Sequence.DO_S6" Destination="DO_S6.D1" dx1="566.67"/>
+			<Connection Source="Sequence.DO_S7" Destination="DO_S7.D1" dx1="266.67"/>
+			<Connection Source="Sequence.DO_S8" Destination="DO_S8.D1" dx1="200"/>
+		</DataConnections>
+		<AdapterConnections>
+			<Connection Source="Sequence.timeOut" Destination="E_TimeOut.TimeOutSocket" dx1="166.67"/>
+		</AdapterConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>


### PR DESCRIPTION
Mirrors the Getreideannahme adapter-3.0.0/logiBUS-3.0.0 changes: SET_<time>
events on sequence_T_08/AnlagenSequenz_06, plus new *_ADAPTER Composite
wrappers bundling outputs into AX adapters and times into ATM sockets.

## Summary by Sourcery

Introduce per-time events and composite adapter wrappers for timed sequence function blocks.

New Features:
- Add SET_<time> events to the timed sequence function blocks AnlagenSequenz_06 and sequence_T_08.
- Add new *_ADAPTER composite function blocks that bundle sequence outputs into AX adapters and timing signals into ATM sockets.