### PR TITLE
Add ANLAGE_AUS signal (TRUE only in S_AUS) for the HAND interlock

### DIFF
--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/ATimeTick.adp
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/ATimeTick.adp
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AdapterType Name="ATimeTick" Comment="Interface for a time out service roughly based on the definitions of ROOM">
+	<Identification Standard="61499-1" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-08-14" Remarks="FB_TON like cyclic Interface">
+	</VersionInfo>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::TimeOut">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="Q"/>
+				<With Var="ET"/>
+				<With Var="PT"/>
+			</Event>
+			<Event Name="STARTO_IN" Type="Event">
+			</Event>
+			<Event Name="STOPO_IN" Type="Event">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="is started = TRUE"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Process time"/>
+			<VarDeclaration Name="ET" Type="TIME" Comment="Elapsed time"/>
+		</InputVars>
+	</InterfaceList>
+	<Service RightInterface="PLUG" LeftInterface="SOCKET">
+		<ServiceSequence Name="Timeout">
+			<ServiceTransaction>
+				<InputPrimitive Interface="PLUG" Event="START" Parameters="TD"/>
+				<OutputPrimitive Interface="SOCKET" Event="START" Parameters="TD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="SOCKET" Event="TimeOut" Parameters=""/>
+				<OutputPrimitive Interface="PLUG" Event="TimeOut"/>
+			</ServiceTransaction>
+		</ServiceSequence>
+		<ServiceSequence Name="NormalOperation">
+			<ServiceTransaction>
+				<InputPrimitive Interface="PLUG" Event="Start" Parameters="TD"/>
+				<OutputPrimitive Interface="SOCKET" Event="Start" Parameters="TD"/>
+			</ServiceTransaction>
+			<ServiceTransaction>
+				<InputPrimitive Interface="PLUG" Event="STOP" Parameters=""/>
+				<OutputPrimitive Interface="SOCKET" Event="STOP" Parameters=""/>
+			</ServiceTransaction>
+		</ServiceSequence>
+	</Service>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</AdapterType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/E_FB_DELAY.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/E_FB_DELAY.fbt
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_FB_DELAY" Comment="Delayed event propagation">
+	<Identification Standard="61499-1 Annex A" Description="Copyright (c) 2017 fortiss GmbH&#10;&#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-08-14" Remarks="FB_TON like cyclic Interface">
+	</VersionInfo>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-21" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::TimeOut">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="REQ" Type="Event" Comment="Normal Execution Request">
+			</Event>
+			<Event Name="START" Type="Event" Comment="Start delayed event propagation">
+				<With Var="DT"/>
+			</Event>
+			<Event Name="STOP" Type="Event" Comment="Stop the delayed event propagation">
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="CNF" Type="Event" Comment="Execution Confirmation">
+				<With Var="ET"/>
+			</Event>
+			<Event Name="STARTO" Type="Event">
+				<With Var="Q"/>
+				<With Var="ET"/>
+				<With Var="PT"/>
+			</Event>
+			<Event Name="STOPO" Type="Event">
+				<With Var="Q"/>
+				<With Var="ET"/>
+			</Event>
+			<Event Name="EO" Type="Event" Comment="Delayed event">
+				<With Var="Q"/>
+				<With Var="ET"/>
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DT" Type="TIME" Comment="Delay time, &gt;0"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output is started = TRUE"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Process time"/>
+			<VarDeclaration Name="ET" Type="TIME" Comment="Elapsed time"/>
+		</OutputVars>
+	</InterfaceList>
+	<BasicFB>
+		<InternalVars>
+			<VarDeclaration Name="StartTime" Type="TIME"/>
+		</InternalVars>
+		<ECC>
+			<ECState Name="Initial_State" Comment="Initial State" x="-1760" y="-80">
+			</ECState>
+			<ECState Name="REQ" x="640" y="-480">
+				<ECAction Algorithm="REQ" Output="CNF"/>
+			</ECState>
+			<ECState Name="START" x="560" y="240">
+				<ECAction Algorithm="START" Output="STARTO"/>
+			</ECState>
+			<ECState Name="STOP" x="560" y="960">
+				<ECAction Algorithm="STOP" Output="STOPO"/>
+			</ECState>
+			<ECState Name="EO" x="3360" y="160">
+				<ECAction Algorithm="EO" Output="EO"/>
+			</ECState>
+			<ECTransition Source="Initial_State" Destination="REQ" Condition="REQ" Comment="" x="-173.33" y="-466.67"/>
+			<ECTransition Source="Initial_State" Destination="START" Condition="START" Comment="" x="-100" y="80"/>
+			<ECTransition Source="Initial_State" Destination="STOP" Condition="STOP" Comment="" x="-533.33" y="680"/>
+			<ECTransition Source="REQ" Destination="EO" Condition="[ET &gt;= DT]" Comment="" x="1886.67" y="-573.33"/>
+			<ECTransition Source="REQ" Destination="Initial_State" Condition="1" Comment="" x="-220" y="-253.33"/>
+			<ECTransition Source="STOP" Destination="Initial_State" Condition="1" Comment="" x="-600" y="846.67"/>
+			<ECTransition Source="START" Destination="EO" Condition="[ET &gt;= DT]" Comment="" x="1953.33" y="66.67"/>
+			<ECTransition Source="START" Destination="Initial_State" Condition="1" Comment="" x="-226.67" y="253.33"/>
+			<ECTransition Source="EO" Destination="Initial_State" Condition="1" Comment="" x="533.33" y="2113.33"/>
+		</ECC>
+		<Algorithm Name="REQ" Comment="Poll elapsed time while armed (Q=TRUE); no-op otherwise. Meant to be driven cyclically (e.g. by an external E_CYCLE) so ET stays live while the delay is running.">
+			<ST><![CDATA[
+VAR_TEMP
+	SysTime : TIME;
+END_VAR
+IF Q THEN
+	SysTime := NOW_MONOTONIC();
+	ET := SysTime - StartTime;
+END_IF;
+
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="START" Comment="Arm the timer: record the start time, reset ET to 0 and set Q=TRUE so REQ begins advancing ET.">
+			<ST><![CDATA[
+StartTime := NOW_MONOTONIC();
+Q := BOOL#TRUE;
+ET := T#0s;
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="STOP" Comment="Cancel the timer without firing EO: clear Q and reset ET to 0.">
+			<ST><![CDATA[
+Q := BOOL#FALSE;
+ET := T#0s;
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="EO" Comment="Runs once when ET reaches DT (via the REQ/START -&gt; EO transition). Clears Q and resets ET to 0, so ET stays below DT until the next START - a later REQ can no longer re-satisfy [ET&gt;=DT] and re-fire EO.">
+			<ST><![CDATA[
+Q := BOOL#FALSE;
+ET := T#0s;
+]]></ST>
+		</Algorithm>
+	</BasicFB>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/E_FB_TimeOut.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/E_FB_TimeOut.fbt
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="E_FB_TimeOut" Comment="Simple implementation of the timeout services">
+	<Identification Standard="61499-1" Description="Copyright (c) 2017 fortiss GmbH&#10; &#10;This program and the accompanying materials are made&#10;available under the terms of the Eclipse Public License 2.0&#10;which is available at https://www.eclipse.org/legal/epl-2.0/&#10;&#10;SPDX-License-Identifier: EPL-2.0">
+	</Identification>
+	<VersionInfo Organization="HR Agrartechnik GmbH" Version="3.1" Author="Franz Höpfinger" Date="2026-08-14" Remarks="FB_TON like cyclic Interface">
+	</VersionInfo>
+	<VersionInfo Version="3.0" Author="Patrick Aigner" Date="2025-04-14" Remarks="changed package">
+	</VersionInfo>
+	<VersionInfo Organization="fortiss GmbH" Version="1.0" Author="Alois Zoitl" Date="2017-09-22" Remarks="initial API and implementation and/or initial documentation">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::TimeOut">
+	</CompilerInfo>
+	<InterfaceList>
+		<Sockets>
+			<AdapterDeclaration Name="TimeTickSocket" Type="adapter::events::TimeOut::ATimeTick"/>
+			<AdapterDeclaration Name="TimeOutSocket" Type="iec61499::events::ATimeOut" x="0" y="400"/>
+		</Sockets>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="DLY" Type="adapter::events::TimeOut::E_FB_DELAY" x="1500" y="300">
+		</FB>
+		<EventConnections>
+			<Connection Source="TimeOutSocket.START" Destination="DLY.START" dx1="400"/>
+			<Connection Source="TimeOutSocket.STOP" Destination="DLY.STOP" dx1="400"/>
+			<Connection Source="DLY.EO" Destination="TimeOutSocket.TimeOut" dx1="1306.67" dx2="1306.67" dy="-1706.67"/>
+			<Connection Source="TimeTickSocket.REQ" Destination="DLY.REQ" dx1="353.33"/>
+			<Connection Source="DLY.CNF" Destination="TimeTickSocket.CNF" dx1="80" dx2="80" dy="-1146.67"/>
+			<Connection Source="DLY.STARTO" Destination="TimeTickSocket.STARTO_IN" dx1="180" dx2="180" dy="-1320"/>
+			<Connection Source="DLY.STOPO" Destination="TimeTickSocket.STOPO_IN" dx1="293.33" dx2="293.33" dy="-1513.33"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="TimeOutSocket.DT" Destination="DLY.DT" dx1="320"/>
+			<Connection Source="DLY.ET" Destination="TimeTickSocket.ET" dx1="426.67" dx2="426.67" dy="233.33"/>
+			<Connection Source="DLY.Q" Destination="TimeTickSocket.Q" dx1="880" dx2="880" dy="606.67"/>
+			<Connection Source="DLY.PT" Destination="TimeTickSocket.PT" dx1="686.67" dx2="686.67" dy="426.67"/>
+		</DataConnections>
+	</FBNetwork>
+	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/TimeTicker.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/adapter-3.0.0/typelib/events/TimeOut/TimeTicker.fbt
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FBType Name="TimeTicker" Comment="Composite FB wrapping other FBs">
+	<Identification Standard="61499-2">
+	</Identification>
+	<VersionInfo Version="1.0" Author="franz" Date="2026-08-15">
+	</VersionInfo>
+	<CompilerInfo packageName="adapter::events::TimeOut">
+	</CompilerInfo>
+	<InterfaceList>
+		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+				<With Var="DC"/>
+			</Event>
+		</EventInputs>
+		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
+			<Event Name="CNF" Type="Event" Comment="Reports the current Q/ET on every tick">
+				<With Var="Q"/>
+				<With Var="ET"/>
+			</Event>
+			<Event Name="STARTO" Type="Event">
+				<With Var="PT"/>
+			</Event>
+			<Event Name="STOPO" Type="Event">
+			</Event>
+		</EventOutputs>
+		<InputVars>
+			<VarDeclaration Name="DC" Type="TIME" Comment="cycleTime" InitialValue="T#200ms"/>
+		</InputVars>
+		<OutputVars>
+			<VarDeclaration Name="Q" Type="BOOL" Comment="Output"/>
+			<VarDeclaration Name="PT" Type="TIME" Comment="Process time"/>
+			<VarDeclaration Name="ET" Type="TIME" Comment="Elapsed time"/>
+		</OutputVars>
+		<Plugs>
+			<AdapterDeclaration Name="TimeTickSocket" Type="adapter::events::TimeOut::ATimeTick"/>
+		</Plugs>
+	</InterfaceList>
+	<FBNetwork>
+		<FB Name="E_CYCLE" Type="iec61499::events::E_CYCLE" x="-1100" y="0">
+		</FB>
+		<EventConnections>
+			<Connection Source="E_CYCLE.EO" Destination="TimeTickSocket.REQ"/>
+			<Connection Source="INIT" Destination="INITO"/>
+			<Connection Source="TimeTickSocket.CNF" Destination="CNF" dx1="2826.67"/>
+			<Connection Source="TimeTickSocket.STARTO_IN" Destination="STARTO" dx1="2880"/>
+			<Connection Source="TimeTickSocket.STOPO_IN" Destination="STOPO" dx1="2960"/>
+			<Connection Source="TimeTickSocket.STARTO_IN" Destination="E_CYCLE.START" dx1="80" dx2="80" dy="-500"/>
+			<Connection Source="TimeTickSocket.STOPO_IN" Destination="E_CYCLE.STOP" dx1="213.33" dx2="213.33" dy="-706.67"/>
+		</EventConnections>
+		<DataConnections>
+			<Connection Source="DC" Destination="E_CYCLE.DT" dx1="653.33"/>
+			<Connection Source="TimeTickSocket.Q" Destination="Q" dx1="3060"/>
+			<Connection Source="TimeTickSocket.ET" Destination="ET" dx1="3340"/>
+			<Connection Source="TimeTickSocket.PT" Destination="PT" dx1="3206.67"/>
+		</DataConnections>
+	</FBNetwork>
+</FBType>

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06.fbt
@@ -17,6 +17,8 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+			</Event>
 			<Event Name="EIN" Type="Event" Comment="Startsequenz auslösen; nur wirksam wenn EINSCHALTBEREIT=TRUE; quittiert dabei zugleich eine anstehende Störungsanzeige">
 			</Event>
 			<Event Name="AUS" Type="Event" Comment="Stopsequenz auslösen, aus jedem Schritt der Vorlauf-Kette oder aus S_LAEUFT">
@@ -71,11 +73,14 @@
 			</Event>
 		</EventInputs>
 		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
 			<Event Name="CNF" Type="Event" Comment="Ausführungsbestätigung, mit jedem Zustands-Update">
 				<With Var="STATUS_BETRIEB"/>
 				<With Var="STATUS_STOERUNG"/>
 				<With Var="ZAEHLSTAND"/>
 				<With Var="EINSCHALTBEREIT"/>
+				<With Var="ANLAGE_AUS"/>
 			</Event>
 			<Event Name="EO_M1" Type="Event" Comment="Laufbefehl Motor 1 aktualisiert (analog EO_Sx in sequence_T_04/_08)">
 				<With Var="DO_M1"/>
@@ -119,6 +124,7 @@
 			<VarDeclaration Name="STATUS_STOERUNG" Type="SINT" Comment="0=keine 4=aktiv, verriegelt bis EIN"/>
 			<VarDeclaration Name="EINSCHALTBEREIT" Type="BOOL" Comment="TRUE nur wenn alle Motoren stehen UND alle Motoren störungsfrei sind"/>
 			<VarDeclaration Name="ZAEHLSTAND" Type="SINT" Comment="0..6, Anzahl aktuell laufender Motoren, s. Konzept"/>
+			<VarDeclaration Name="ANLAGE_AUS" Type="BOOL" Comment="TRUE nur in S_AUS (STATUS_BETRIEB = Aus) - Voraussetzung fuer Handbetrieb"/>
 			<VarDeclaration Name="DO_M1" Type="BOOL" Comment="Laufbefehl Motor 1"/>
 			<VarDeclaration Name="DO_M2" Type="BOOL" Comment="Laufbefehl Motor 2"/>
 			<VarDeclaration Name="DO_M3" Type="BOOL" Comment="Laufbefehl Motor 3"/>
@@ -133,6 +139,9 @@
 	<BasicFB>
 		<ECC>
 			<ECState Name="xSTART" Comment="Initial State" x="5600" y="11200">
+			</ECState>
+			<ECState Name="Init" Comment="Initialization" x="4240" y="11280">
+				<ECAction Output="INITO"/>
 			</ECState>
 			<ECState Name="sAUS" Comment="S_AUS, unten im Ring: keine Motoren laufen" x="5600" y="9600">
 				<ECAction Algorithm="S_AUS_Setup"/>
@@ -276,7 +285,6 @@
 				<ECAction Output="timeOut.START"/>
 				<ECAction Output="CNF"/>
 			</ECState>
-			<ECTransition Source="xSTART" Destination="sAUS" Condition="1" Comment="" x="5566.67" y="0"/>
 			<ECTransition Source="sAUS" Destination="sVOR1" Condition="EIN[NOT (STOERUNG_M1 OR STOERUNG_M2 OR STOERUNG_M3 OR STOERUNG_M4 OR STOERUNG_M5 OR STOERUNG_M6)]" Comment="" x="2746.67" y="9840"/>
 			<ECTransition Source="sVOR1" Destination="sVOR2" Condition="timeOut.TimeOut" Comment="" x="673.33" y="7133.33"/>
 			<ECTransition Source="sVOR1" Destination="sNACH5" Condition="AUS" Comment="" x="3560" y="8160"/>
@@ -345,18 +353,30 @@
 			<ECTransition Source="sNACH4" Destination="sAUS" Condition="EI_M6[STOERUNG_M6]" Comment="" x="4666.67" y="8960"/>
 			<ECTransition Source="sNACH5" Destination="sAUS" Condition="timeOut.TimeOut" Comment="" x="5540" y="8853.33"/>
 			<ECTransition Source="sNACH5" Destination="sAUS" Condition="EI_M6[STOERUNG_M6]" Comment="" x="4666.67" y="9226.67"/>
-			<ECTransition Source="sVOR1" Destination="sVOR1" Condition="SET_ZE1_EIN" Comment="Live-Update: laeuft timeOut mit ZE1_EIN gerade, S_VOR1_Setup neu ausfuehren"/>
-			<ECTransition Source="sVOR2" Destination="sVOR2" Condition="SET_ZE2_EIN" Comment="Live-Update: laeuft timeOut mit ZE2_EIN gerade, S_VOR2_Setup neu ausfuehren"/>
-			<ECTransition Source="sVOR3" Destination="sVOR3" Condition="SET_ZE3_EIN" Comment="Live-Update: laeuft timeOut mit ZE3_EIN gerade, S_VOR3_Setup neu ausfuehren"/>
-			<ECTransition Source="sVOR4" Destination="sVOR4" Condition="SET_ZE4_EIN" Comment="Live-Update: laeuft timeOut mit ZE4_EIN gerade, S_VOR4_Setup neu ausfuehren"/>
-			<ECTransition Source="sVOR5" Destination="sVOR5" Condition="SET_ZE5_EIN" Comment="Live-Update: laeuft timeOut mit ZE5_EIN gerade, S_VOR5_Setup neu ausfuehren"/>
-			<ECTransition Source="sNACH1" Destination="sNACH1" Condition="SET_ZE1_AUS" Comment="Live-Update: laeuft timeOut mit ZE1_AUS gerade, S_NACH1_Setup neu ausfuehren"/>
-			<ECTransition Source="sNACH2" Destination="sNACH2" Condition="SET_ZE2_AUS" Comment="Live-Update: laeuft timeOut mit ZE2_AUS gerade, S_NACH2_Setup neu ausfuehren"/>
-			<ECTransition Source="sNACH3" Destination="sNACH3" Condition="SET_ZE3_AUS" Comment="Live-Update: laeuft timeOut mit ZE3_AUS gerade, S_NACH3_Setup neu ausfuehren"/>
-			<ECTransition Source="sNACH4" Destination="sNACH4" Condition="SET_ZE4_AUS" Comment="Live-Update: laeuft timeOut mit ZE4_AUS gerade, S_NACH4_Setup neu ausfuehren"/>
-			<ECTransition Source="sNACH5" Destination="sNACH5" Condition="SET_ZE5_AUS" Comment="Live-Update: laeuft timeOut mit ZE5_AUS gerade, S_NACH5_Setup neu ausfuehren"/>
+			<ECTransition Source="sVOR1" Destination="sVOR1" Condition="SET_ZE1_EIN" Comment="" x="0" y="0"/>
+			<ECTransition Source="sVOR2" Destination="sVOR2" Condition="SET_ZE2_EIN" Comment="" x="0" y="0"/>
+			<ECTransition Source="sVOR3" Destination="sVOR3" Condition="SET_ZE3_EIN" Comment="" x="0" y="0"/>
+			<ECTransition Source="sVOR4" Destination="sVOR4" Condition="SET_ZE4_EIN" Comment="" x="0" y="0"/>
+			<ECTransition Source="sVOR5" Destination="sVOR5" Condition="SET_ZE5_EIN" Comment="" x="0" y="0"/>
+			<ECTransition Source="sNACH1" Destination="sNACH1" Condition="SET_ZE1_AUS" Comment="" x="0" y="0"/>
+			<ECTransition Source="sNACH2" Destination="sNACH2" Condition="SET_ZE2_AUS" Comment="" x="0" y="0"/>
+			<ECTransition Source="sNACH3" Destination="sNACH3" Condition="SET_ZE3_AUS" Comment="" x="0" y="0"/>
+			<ECTransition Source="sNACH4" Destination="sNACH4" Condition="SET_ZE4_AUS" Comment="" x="0" y="0"/>
+			<ECTransition Source="sNACH5" Destination="sNACH5" Condition="SET_ZE5_AUS" Comment="" x="0" y="0"/>
+			<ECTransition Source="xSTART" Destination="Init" Condition="INIT" Comment="" x="4826.67" y="11806.67"/>
+			<ECTransition Source="Init" Destination="sAUS" Condition="1" Comment="" x="4920" y="10440"/>
 		</ECC>
-		<Algorithm Name="EI_CYCLIC_Auswertung" Comment="Liest STOERUNG_M1..M6 neu ein, setzt STATUS_STOERUNG falls eine aktiv ist, und berechnet&#10;EINSCHALTBEREIT">
+		<Algorithm Name="initialize" Comment="Initialization algorithm">
+			<ST><![CDATA[
+
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="deInitialize" Comment="Normally executed algorithm">
+			<ST><![CDATA[
+
+]]></ST>
+		</Algorithm>
+		<Algorithm Name="EI_CYCLIC_Auswertung" Comment="Liest STOERUNG_M1..M6 neu ein, setzt STATUS_STOERUNG falls eine aktiv ist, und berechnet&#10;EINSCHALTBEREIT/ANLAGE_AUS">
 			<ST><![CDATA[
 // Störungssignale frisch einlesen (BOOL-Dauersignale, kein Event-Consumption-Problem, s. Konzept
 // Frage 4)
@@ -369,6 +389,10 @@ END_IF;
 // selbst kommt aber nur an, wenn EINSCHALTBEREIT die Visu-Sperre freigibt - sonst Deadlock.
 EINSCHALTBEREIT := (ZAEHLSTAND = 0)
 	AND NOT (STOERUNG_M1 OR STOERUNG_M2 OR STOERUNG_M3 OR STOERUNG_M4 OR STOERUNG_M5 OR STOERUNG_M6);
+
+// Voraussetzung fuer Handbetrieb: nur wenn die Anlage wirklich in S_AUS steht (unabhaengig von
+// Stoerungen - eine Stoerung soll Handbetrieb zum Freifahren nicht zusaetzlich blockieren).
+ANLAGE_AUS := (STATUS_BETRIEB = anlagenSequenz::STATUS_BETRIEB_AUS);
 ]]></ST>
 		</Algorithm>
 		<Algorithm Name="M1_EIN" Comment="Setzt den Laufbefehl DO_M1 auf TRUE (Motor 1 einschalten)">

--- a/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06_ADAPTER.fbt
+++ b/Ventilsteuerung/4diacIDE-workspace/.lib/logiBUS-3.0.0/typelib/utils/sequence/timed/AnlagenSequenz_06_ADAPTER.fbt
@@ -8,12 +8,16 @@
 	</CompilerInfo>
 	<InterfaceList>
 		<EventInputs>
+			<Event Name="INIT" Type="EInit" Comment="Initialization Request">
+			</Event>
 			<Event Name="EIN" Type="Event" Comment="Startsequenz auslösen; nur wirksam wenn EINSCHALTBEREIT=TRUE; quittiert dabei zugleich eine anstehende Störungsanzeige">
 			</Event>
 			<Event Name="AUS" Type="Event" Comment="Stopsequenz auslösen, aus jedem Schritt der Vorlauf-Kette oder aus S_LAEUFT">
 			</Event>
 		</EventInputs>
 		<EventOutputs>
+			<Event Name="INITO" Type="EInit" Comment="Initialization Confirm">
+			</Event>
 			<Event Name="CNF" Type="Event" Comment="Ausführungsbestätigung, mit jedem Zustands-Update">
 				<With Var="STATUS_BETRIEB"/>
 				<With Var="STATUS_STOERUNG"/>
@@ -34,6 +38,9 @@
 			<AdapterDeclaration Name="DO_M4" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 4" x="5460" y="5626.67"/>
 			<AdapterDeclaration Name="DO_M5" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 5" x="5326.67" y="6420"/>
 			<AdapterDeclaration Name="DO_M6" Type="adapter::types::unidirectional::AX" Comment="Laufbefehl Motor 6" x="5193.33" y="7213.33"/>
+			<AdapterDeclaration Name="ANLAGE_AUS" Type="adapter::types::unidirectional::AX" Comment="TRUE nur in S_AUS - Voraussetzung fuer Handbetrieb" x="6500" y="7600"/>
+			<AdapterDeclaration Name="PT" Type="adapter::types::unidirectional::ATM" Comment="Process time" x="7500" y="8700"/>
+			<AdapterDeclaration Name="ET" Type="adapter::types::unidirectional::ATM" Comment="Elapsed time" x="8600" y="8500"/>
 		</Plugs>
 		<Sockets>
 			<AdapterDeclaration Name="ATM_ZE1_EIN" Type="adapter::types::unidirectional::ATM" Comment="S_VOR1 zu S_VOR2, M5 startet (Vorlauf)" x="673.33" y="-786.67"/>
@@ -57,7 +64,10 @@
 	<FBNetwork>
 		<FB Name="Sequence" Type="logiBUS::utils::sequence::timed::AnlagenSequenz_06" x="3600" y="1900">
 		</FB>
-		<FB Name="E_TimeOut" Type="iec61499::events::E_TimeOut" x="4993.33" y="8033.33">
+		<FB Name="E_TimeOut" Type="adapter::events::TimeOut::E_FB_TimeOut" x="6900" y="9300">
+		</FB>
+		<FB Name="TimeTicker" Type="adapter::events::TimeOut::TimeTicker" x="5500" y="8300">
+			<Parameter Name="DC" Value="T#200ms"/>
 		</FB>
 		<EventConnections>
 			<Connection Source="EIN" Destination="Sequence.EIN" dx1="2626.67"/>
@@ -79,12 +89,18 @@
 			<Connection Source="STOERUNG_M5.E1" Destination="Sequence.EI_M5" dx1="1233.33"/>
 			<Connection Source="STOERUNG_M6.E1" Destination="Sequence.EI_M6" dx1="1233.33"/>
 			<Connection Source="Sequence.CNF" Destination="CNF" dx1="66.67"/>
+			<Connection Source="Sequence.CNF" Destination="ANLAGE_AUS.E1" dx1="66.67"/>
 			<Connection Source="Sequence.EO_M1" Destination="DO_M1.E1" dx1="866.67"/>
 			<Connection Source="Sequence.EO_M2" Destination="DO_M2.E1" dx1="800"/>
 			<Connection Source="Sequence.EO_M3" Destination="DO_M3.E1" dx1="666.67"/>
 			<Connection Source="Sequence.EO_M4" Destination="DO_M4.E1" dx1="533.33"/>
 			<Connection Source="Sequence.EO_M5" Destination="DO_M5.E1" dx1="400"/>
 			<Connection Source="Sequence.EO_M6" Destination="DO_M6.E1" dx1="266.67"/>
+			<Connection Source="INIT" Destination="Sequence.INIT" dx1="3006.67"/>
+			<Connection Source="Sequence.INITO" Destination="TimeTicker.INIT" dx1="393.33"/>
+			<Connection Source="TimeTicker.INITO" Destination="INITO" dx1="2600"/>
+			<Connection Source="TimeTicker.CNF" Destination="ET.E1" dx1="333.33"/>
+			<Connection Source="TimeTicker.STARTO" Destination="PT.E1" dx1="586.67"/>
 		</EventConnections>
 		<DataConnections>
 			<Connection Source="ATM_ZE1_EIN.D1" Destination="Sequence.ZE1_EIN" dx1="2093.33"/>
@@ -107,15 +123,19 @@
 			<Connection Source="Sequence.STATUS_STOERUNG" Destination="STATUS_STOERUNG" dx1="333.33"/>
 			<Connection Source="Sequence.ZAEHLSTAND" Destination="ZAEHLSTAND" dx1="600"/>
 			<Connection Source="Sequence.EINSCHALTBEREIT" Destination="EINSCHALTBEREIT" dx1="466.67"/>
+			<Connection Source="Sequence.ANLAGE_AUS" Destination="ANLAGE_AUS.D1" dx1="466.67"/>
 			<Connection Source="Sequence.DO_M1" Destination="DO_M1.D1" dx1="733.33"/>
 			<Connection Source="Sequence.DO_M2" Destination="DO_M2.D1" dx1="800"/>
 			<Connection Source="Sequence.DO_M3" Destination="DO_M3.D1" dx1="466.67"/>
 			<Connection Source="Sequence.DO_M4" Destination="DO_M4.D1" dx1="333.33"/>
 			<Connection Source="Sequence.DO_M5" Destination="DO_M5.D1" dx1="200"/>
 			<Connection Source="Sequence.DO_M6" Destination="DO_M6.D1" dx1="133.33"/>
+			<Connection Source="TimeTicker.ET" Destination="ET.D1" dx1="2193.33"/>
+			<Connection Source="TimeTicker.PT" Destination="PT.D1" dx1="586.67"/>
 		</DataConnections>
 		<AdapterConnections>
 			<Connection Source="Sequence.timeOut" Destination="E_TimeOut.TimeOutSocket" dx1="66.67"/>
+			<Connection Source="TimeTicker.TimeTickSocket" Destination="E_TimeOut.TimeTickSocket" dx1="160"/>
 		</AdapterConnections>
 	</FBNetwork>
 	<Attribute Name="eclipse4diac::core::TypeHash" Value="''"/>


### PR DESCRIPTION
Mirrors the Getreideannahme change: computed in EI_CYCLIC_Auswertung,
exposed as an AX plug through AnlagenSequenz_06_ADAPTER.

Add A_FB_TimeOut/E_FB_DELAY/E_FB_TimeOut (ATimeOut-alike with elapsed-time readback)

Mirrors the Getreideannahme adapter-3.0.0 addition, already fixed for the
STOP/EO conflation and unarmed-REQ edge case (see Getreideannahme's
Ventilsteuerung/NOTIZ_E_FB_DELAY_Review.md for the review history).

gitflow-feature-stash: TimeOutTicker

## Summary by Sourcery

Extend the HAND interlock sequence with an S_AUS-specific status signal and reusable timeout monitoring with elapsed-time feedback.

New Features:
- Add the ANLAGE_AUS signal for HAND interlock logic, active only while the sequence is in S_AUS and exposed through the AnlagenSequenz adapter.
- Add timeout event interfaces with start/stop control and elapsed-time readback for sequence timing.

Enhancements:
- Update the timed AnlagenSequenz implementation and adapter to support the new interlock signal and timeout functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable timeout and time-ticker function blocks for timed event handling.
  * Added support for configurable delays, elapsed-time reporting, start/stop controls, and timeout notifications.
  * Added initialization events and plant-off status output to the timed plant sequence.
* **Enhancements**
  * Updated the plant sequence to use the new adapter-based timeout handling.
  * Added periodic ticker outputs and improved forwarding of timeout, timing, and status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->